### PR TITLE
Add support for osx-arm64 for Java and Rust

### DIFF
--- a/src/multilspy/language_servers/eclipse_jdtls/eclipse_jdtls.py
+++ b/src/multilspy/language_servers/eclipse_jdtls/eclipse_jdtls.py
@@ -150,10 +150,10 @@ class EclipseJDTLS(LanguageServer):
 
         os.makedirs(str(PurePath(os.path.abspath(os.path.dirname(__file__)), "static")), exist_ok=True)
 
-        assert platformId.value in [
-            "linux-x64",
-            "win-x64",
-        ], "Only linux-x64 platform is supported for in multilspy at the moment"
+        # assert platformId.value in [
+        #     "linux-x64",
+        #     "win-x64",
+        # ], "Only linux-x64 platform is supported for in multilspy at the moment"
 
         gradle_path = str(
             PurePath(

--- a/src/multilspy/language_servers/eclipse_jdtls/runtime_dependencies.json
+++ b/src/multilspy/language_servers/eclipse_jdtls/runtime_dependencies.json
@@ -13,10 +13,15 @@
             "archiveType": "zip",
             "relative_extraction_path": "vscode-java"
         },
-        "darwin-x64": {
+        "osx-arm64": {
             "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@darwin-x64-1.23.0.vsix",
             "archiveType": "zip",
-            "relative_extraction_path": "vscode-java"
+            "relative_extraction_path": "vscode-java",
+            "jre_home_path": "extension/jre/17.0.8.1-macosx-x86_64",
+            "jre_path": "extension/jre/17.0.8.1-macosx-x86_64/bin/java",
+            "lombok_jar_path": "extension/lombok/lombok-1.18.30.jar",
+            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.6.500.v20230717-2134.jar",
+            "jdtls_readonly_config_path": "extension/server/config_mac_arm"
         },
         "linux-arm64": {
             "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@linux-arm64-1.23.0.vsix",

--- a/src/multilspy/language_servers/rust_analyzer/runtime_dependencies.json
+++ b/src/multilspy/language_servers/rust_analyzer/runtime_dependencies.json
@@ -1,6 +1,14 @@
 {
     "_description": "Used to download the runtime dependencies for running RustAnalyzer. Obtained from https://github.com/rust-lang/rust-analyzer/releases",
     "runtimeDependencies": [
+                {
+            "id": "RustAnalyzer",
+            "description": "RustAnalyzer for Linux (x64)",
+            "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-10-09/rust-analyzer-aarch64-apple-darwin.gz",
+            "platformId": "osx-arm64",
+            "archiveType": "gz",
+            "binaryName": "rust_analyzer"
+        },
         {
             "id": "RustAnalyzer",
             "description": "RustAnalyzer for Linux (x64)",

--- a/src/multilspy/language_servers/rust_analyzer/rust_analyzer.py
+++ b/src/multilspy/language_servers/rust_analyzer/rust_analyzer.py
@@ -49,10 +49,10 @@ class RustAnalyzer(LanguageServer):
             d = json.load(f)
             del d["_description"]
 
-        assert platform_id.value in [
-            "linux-x64",
-            "win-x64",
-        ], "Only linux-x64 and win-x64 platform is supported for in multilspy at the moment"
+        # assert platform_id.value in [
+        #     "linux-x64",
+        #     "win-x64",
+        # ], "Only linux-x64 and win-x64 platform is supported for in multilspy at the moment"
 
         runtime_dependencies = d["runtimeDependencies"]
         runtime_dependencies = [


### PR DESCRIPTION
This PR extends the support of `multispy` for Java and Rust also to Mac computers


### Example results
On Rust, for example, I tested it on the repo: https://github.com/rust-lang/rfcbot-rs

```
project_dir = workspace/rfcbot-rs-master'
rel_file = "src/config.rs"
```

Results:
```
================
For the file '/workspace/rfcbot-rs-master/src/config.rs', here are the files referenced by it (context):

/workspace/rfcbot-rs-master/src/macros.rs


================
For the file '/Users/talrid/Git/rfcbot-rs-master/src/config.rs', here are the files referencing it (reverse context):

/workspace/rfcbot-rs-master/src/scraper.rs
/workspace/rfcbot-rs-master/src/main.rs
/workspace/rfcbot-rs-master/src/github/command.rs
================
```

Related: #28 