### PR TITLE
Catch FileNotFoundError when 'dotnet' is not in the system

### DIFF
--- a/src/multilspy/multilspy_utils.py
+++ b/src/multilspy/multilspy_utils.py
@@ -239,9 +239,10 @@ class PlatformUtils:
                 return DotnetVersion.V4
             else:
                 raise MultilspyException("Unknown dotnet version: " + version)
-        except subprocess.CalledProcessError:
+        except (FileNotFoundError, subprocess.CalledProcessError):
             try:
                 result = subprocess.run(["mono", "--version"], capture_output=True, check=True)
                 return DotnetVersion.VMONO
-            except subprocess.CalledProcessError:
+            except (FileNotFoundError, subprocess.CalledProcessError):
                 raise MultilspyException("dotnet or mono not found on the system")
+


### PR DESCRIPTION
For some reason, **subprocess.run** raises a **FileNotFoundError** instead of a **CalledProcessError** when the executable (dotnet) is not present on the system. This causes *mono* not to be tried, since **FileNotFoundError** is not caught.

Fix: Include **FileNotFoundError** in the **except** blocks.