### PR TITLE
Make workspace configurable for jdtls.

### DIFF
--- a/src/multilspy/multilspy_config.py
+++ b/src/multilspy/multilspy_config.py
@@ -4,6 +4,8 @@ Configuration parameters for Multilspy.
 
 from enum import Enum
 from dataclasses import dataclass
+from pathlib import Path
+
 
 class Language(str, Enum):
     """
@@ -26,7 +28,12 @@ class MultilspyConfig:
     Configuration parameters
     """
     code_language: Language
+
     trace_lsp_communication: bool = False
+
+    ws_path: Path = None
+
+    temp_workspace: bool = False
 
     @classmethod
     def from_dict(cls, env: dict):

--- a/src/multilspy/multilspy_utils.py
+++ b/src/multilspy/multilspy_utils.py
@@ -107,6 +107,9 @@ class FileUtils:
                         return inp_file.read()
                 except UnicodeError:
                     continue
+        except FileNotFoundError as exc:
+            logger.log(f"File'{file_path}' not found: {exc}", logging.ERROR)
+            raise MultilspyException(f"File not found {file_path}") from None
         except Exception as exc:
             logger.log(f"File read '{file_path}' failed: {exc}", logging.ERROR)
             raise MultilspyException("File read failed.") from None
@@ -245,4 +248,3 @@ class PlatformUtils:
                 return DotnetVersion.VMONO
             except (FileNotFoundError, subprocess.CalledProcessError):
                 raise MultilspyException("dotnet or mono not found on the system")
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 import contextlib
 import shutil
+import uuid
 
 from multilspy.multilspy_config import MultilspyConfig
 from multilspy.multilspy_logger import MultilspyLogger
@@ -11,11 +12,12 @@ from uuid import uuid4
 from multilspy.multilspy_utils import FileUtils
 
 @contextlib.contextmanager
-def create_test_context(params: dict) -> Iterator[MultilspyContext]:
+def create_test_context(params: dict, temp_workspace=True) -> Iterator[MultilspyContext]:
     """
     Creates a test context for the given parameters.
     """
     config = MultilspyConfig.from_dict(params)
+    config.temp_workspace = temp_workspace
     logger = MultilspyLogger()
 
     user_home_dir = os.path.expanduser("~")


### PR DESCRIPTION
Closes #34 

This PR affects only Eclipse **JDTLS** and introduces no breaking changes.
It adds the ability to specify the workspace directory path used by the JDTLS server through the `MultilspyConfig` class:

```
class MultilspyConfig:
    ...
    ws_path: Path = None
    temp_workspace: bool = False
    ...
```

By default, the `ws_path` property is `None`, and Eclipse JDTLS creates a new workspace for the current project. If the `temp_workspace` config property is set to false, Eclipse JDTLS will register the new workspace and associate it with the current project. This association is persisted in a file named `ws_table` in the Eclipse JDTLS directory.

Upon stopping, the server will clean up the new workspace if `temp_workspace` is true. If the workspace path was provided by the client, the behavior remains similar, except that the workspace is not removed even if `temp_workspace` is set to true.