### PR TITLE
Specify `--prefix` for `npm install` command for `typescript` and `typescript-language-server`

### DIFF
--- a/src/multilspy/language_servers/typescript_language_server/runtime_dependencies.json
+++ b/src/multilspy/language_servers/typescript_language_server/runtime_dependencies.json
@@ -1,15 +1,16 @@
 {
-    "_description": "Used to download the runtime dependencies for running typescript-language-server. Obtained from https://github.com/typescript-language-server/typescript-language-server/releases",
-    "runtimeDependencies": [
-        {
-            "id": "typescript",
-            "description": "typescript package for Linux, OSX, and Windows. Both x64 and arm64 are supported.",
-            "command": "npm install typescript@5.5.4"
-        },
-        {
-            "id": "typescript-language-server",
-            "description": "typescript-language-server package for Linux, OSX, and Windows. Both x64 and arm64 are supported.",
-            "command": "npm install typescript-language-server@4.3.3"
-        }
-    ]
+  "_description": "Used to download the runtime dependencies for running typescript-language-server. Obtained from https://github.com/typescript-language-server/typescript-language-server/releases",
+  "runtimeDependencies": [
+    {
+      "id": "typescript",
+      "description": "typescript package for Linux, OSX, and Windows. Both x64 and arm64 are supported.",
+      "command": "npm install --prefix ./ typescript@5.5.4"
+    },
+    {
+      "id": "typescript-language-server",
+      "description": "typescript-language-server package for Linux, OSX, and Windows. Both x64 and arm64 are supported.",
+      "command": "npm install --prefix ./ typescript-language-server@4.3.3"
+    }
+  ]
 }
+


### PR DESCRIPTION
In certain setups, `multilspy` might be installed at a location where a parent directory has a `node_modules` folder already. For example, in a docker container, `multilspy` will most likely just be under `/usr/local/lib/python` and if there is any `npm` installed global dependencies, there will also be a `/usr/local/lib/node_modules` folder.

In such a setup, `npm install typescript` will put the executable under `/usr/local/lib/node_modules` when `setup_runtime_dependencies` is run for `typescript` repos. This will cause the assert for checking `typescript-language-server` being located under `multilspy/language_servers/typescript_language_server/static/ts-lsp` to fail right after the installation.

We can fix this issue by adding `--prefix ./` to the `npm install` command in the settings file. This PR implements that fix.