### PR TITLE
Add psutil dependency and enhance process termination handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ classifiers = [
 dependencies = [
   "jedi-language-server==0.41.1",
   "requests==2.32.3",
-  "typing-extensions>=4.2.0"
+  "typing-extensions>=4.2.0",
+  "psutil (>=7.0.0,<8.0.0)"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytest==7.3.1
 pytest-asyncio==0.21.1
 requests==2.32.3
 typing-extensions>=4.2.0
+psutil>=7.0.0,<8.0.0

--- a/src/multilspy/lsp_protocol_handler/server.py
+++ b/src/multilspy/lsp_protocol_handler/server.py
@@ -32,6 +32,7 @@ import asyncio
 import dataclasses
 import json
 import os
+import psutil
 from typing import Any, Dict, List, Optional, Union
 
 from .lsp_requests import LspNotification, LspRequest
@@ -240,6 +241,10 @@ class LanguageServerHandler:
                 await asyncio.wait_for(wait_for_end, timeout=60)
             except asyncio.TimeoutError:
                 process.kill()
+
+                for child in psutil.Process(process.pid).children(recursive=True):
+                    child.kill()
+
 
     async def shutdown(self) -> None:
         """


### PR DESCRIPTION
Sometimes, when OmniSharp hangs, it leaves a RazorSharp process running. This PR ensures that the child processes are also terminated