### PR TITLE
fix race condition in process termination

### DIFF
--- a/src/multilspy/lsp_protocol_handler/server.py
+++ b/src/multilspy/lsp_protocol_handler/server.py
@@ -240,10 +240,10 @@ class LanguageServerHandler:
             try:
                 await asyncio.wait_for(wait_for_end, timeout=60)
             except asyncio.TimeoutError:
-                process.kill()
-
                 for child in psutil.Process(process.pid).children(recursive=True):
                     child.kill()
+                
+                process.kill()
 
 
     async def shutdown(self) -> None:


### PR DESCRIPTION
Ensure child processes are collected before killing the main process to prevent NoSuchProcess errors and ensure all children are properly terminated.