### PR TITLE
Add messages to assertion failures in `request_references` and `request_document_symbols`

### DIFF
--- a/src/multilspy/language_server.py
+++ b/src/multilspy/language_server.py
@@ -467,7 +467,7 @@ class LanguageServer:
             )
 
         ret: List[multilspy_types.Location] = []
-        assert isinstance(response, list)
+        assert isinstance(response, list), f"Unexpected response from Language Server: {response}"
         for item in response:
             assert isinstance(item, dict)
             assert LSPConstants.URI in item
@@ -597,7 +597,7 @@ class LanguageServer:
         
         ret: List[multilspy_types.UnifiedSymbolInformation] = []
         l_tree = None
-        assert isinstance(response, list)
+        assert isinstance(response, list), f"Unexpected response from Language Server: {response}"
         for item in response:
             assert isinstance(item, dict)
             assert LSPConstants.NAME in item


### PR DESCRIPTION
When calling the language server, it could return `None` in cases where the input symbol or document is not found. The assertion statements changed here are mostly will be triggered in those cases. However, these cases could be considered expected, rather than errors, so callers should have the choice of catching them and handling them as desired. Without a message accompanying the assertion failure, it's very hard to do so. This PR adds a consistent message to these kinds of failures and they match the existing value inside `request_definition` in a similar situation.

This change is fairly minimal and more or less allows me what I would like to accomplish in my project, which is making sure that I return a nice user error in these "expected" error situations, rather than an uncaught server error. However, I do think the most appropriate thing to do here is let all these methods return `None` in addition to the `List`/`Tuple`. This would match the actual language server protocol where `null` is a possible return type. But the change in return type would imply a breaking change so I'm not sure if that's something worthy of doing without a super compelling reason.

Alternatively, we could also define a new `NotFoundError` and raise that error explicitly when the language server returns `null`. If that's a preferred way to handle this situation, I'm happy to take that approach and update this PR.