### PR TITLE
Let language server subprocess be its own process group

### DIFF
--- a/src/multilspy/language_server.py
+++ b/src/multilspy/language_server.py
@@ -159,7 +159,11 @@ class LanguageServer:
 
         # cmd is obtained from the child classes, which provide the language specific command to start the language server
         # LanguageServerHandler provides the functionality to start the language server and communicate with it
-        self.server: LanguageServerHandler = LanguageServerHandler(process_launch_info, logger=logging_fn)
+        self.server: LanguageServerHandler = LanguageServerHandler(
+            process_launch_info,
+            logger=logging_fn,
+            start_independent_lsp_process=config.start_independent_lsp_process,
+        )
 
         self.language_id = language_id
         self.open_file_buffers: Dict[str, LSPFileBuffer] = {}

--- a/src/multilspy/lsp_protocol_handler/server.py
+++ b/src/multilspy/lsp_protocol_handler/server.py
@@ -172,9 +172,18 @@ class LanguageServerHandler:
             the asynchronous tasks created by the handler.
         task_counter: An integer that represents the next available task id for the handler.
         loop: An asyncio.AbstractEventLoop object that represents the event loop used by the handler.
+        start_independent_lsp_process: An optional boolean flag that indicates whether to start the
+        language server process in an independent process group. Default is `True`. Setting it to
+        `False` means that the language server process will be in the same process group as the
+        the current process, and any SIGINT and SIGTERM signals will be sent to both processes.
     """
 
-    def __init__(self, process_launch_info: ProcessLaunchInfo, logger=None) -> None:
+    def __init__(
+        self,
+        process_launch_info: ProcessLaunchInfo,
+        logger=None,
+        start_independent_lsp_process=True,
+    ) -> None:
         """
         Params:
             cmd: A string that represents the command to launch the language server process.
@@ -196,6 +205,7 @@ class LanguageServerHandler:
         self.tasks = {}
         self.task_counter = 0
         self.loop = None
+        self.start_independent_lsp_process = start_independent_lsp_process
 
     async def start(self) -> None:
         """
@@ -211,7 +221,7 @@ class LanguageServerHandler:
             stderr=asyncio.subprocess.PIPE,
             env=child_proc_env,
             cwd=self.process_launch_info.cwd,
-            start_new_session=True,
+            start_new_session=self.start_independent_lsp_process,
         )
 
         self.loop = asyncio.get_event_loop()

--- a/src/multilspy/lsp_protocol_handler/server.py
+++ b/src/multilspy/lsp_protocol_handler/server.py
@@ -211,6 +211,7 @@ class LanguageServerHandler:
             stderr=asyncio.subprocess.PIPE,
             env=child_proc_env,
             cwd=self.process_launch_info.cwd,
+            start_new_session=True,
         )
 
         self.loop = asyncio.get_event_loop()

--- a/src/multilspy/multilspy_config.py
+++ b/src/multilspy/multilspy_config.py
@@ -30,6 +30,7 @@ class MultilspyConfig:
     """
     code_language: Language
     trace_lsp_communication: bool = False
+    start_independent_lsp_process: bool = True
 
     @classmethod
     def from_dict(cls, env: dict):


### PR DESCRIPTION
In situations where `multilspy` is launched from another process, a SIGINT or SIGTERM signal will be received by both the launching process as well as the process running the language server because `asyncio.create_subprocess_shell` defaults to `start_new_session=False`. In such a situation, `lsp_protocol_handler.server.shutdown` will be called but will hang since the underlying process is already terminated, `lsp_protocol_handler.server` won't ever receive an answer back for `shutdown`.

This change makes it so that SIGINT and SIGTERM won't propagate to the language server process. We rely on the clean up code already in place to shut down the process as desired.

See [python documentation](https://docs.python.org/3.13/library/subprocess.html#subprocess.Popen) for more details on `start_new_session`