### PR TITLE
feat: add kotlin language support

### DIFF
--- a/src/multilspy/language_server.py
+++ b/src/multilspy/language_server.py
@@ -85,6 +85,12 @@ class LanguageServer:
             )
 
             return EclipseJDTLS(config, logger, repository_root_path)
+        elif config.code_language == Language.KOTLIN:
+            from multilspy.language_servers.kotlin_language_server.kotlin_language_server import (
+                KotlinLanguageServer,
+            )
+
+            return KotlinLanguageServer(config, logger, repository_root_path)
         elif config.code_language == Language.RUST:
             from multilspy.language_servers.rust_analyzer.rust_analyzer import (
                 RustAnalyzer,

--- a/src/multilspy/language_servers/kotlin_language_server/initialize_params.json
+++ b/src/multilspy/language_servers/kotlin_language_server/initialize_params.json
@@ -1,0 +1,849 @@
+{
+    "_description": "The parameters sent by the client when initializing the language server with the \"initialize\" request. More details at https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize",
+    "processId": "os.getpid()",
+    "clientInfo": {
+        "name": "Visual Studio Code - Insiders",
+        "version": "1.77.0-insider"
+    },
+    "locale": "en",
+    "rootPath": "repository_absolute_path",
+    "rootUri": "pathlib.Path(repository_absolute_path).as_uri()",
+    "capabilities": {
+        "workspace": {
+            "applyEdit": true,
+            "workspaceEdit": {
+                "documentChanges": true,
+                "resourceOperations": [
+                    "create",
+                    "rename",
+                    "delete"
+                ],
+                "failureHandling": "textOnlyTransactional",
+                "normalizesLineEndings": true,
+                "changeAnnotationSupport": {
+                    "groupsOnLabel": true
+                }
+            },
+            "didChangeConfiguration": {
+                "dynamicRegistration": true
+            },
+            "didChangeWatchedFiles": {
+                "dynamicRegistration": true,
+                "relativePatternSupport": true
+            },
+            "symbol": {
+                "dynamicRegistration": true,
+                "symbolKind": {
+                    "valueSet": [
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        8,
+                        9,
+                        10,
+                        11,
+                        12,
+                        13,
+                        14,
+                        15,
+                        16,
+                        17,
+                        18,
+                        19,
+                        20,
+                        21,
+                        22,
+                        23,
+                        24,
+                        25,
+                        26
+                    ]
+                },
+                "tagSupport": {
+                    "valueSet": [
+                        1
+                    ]
+                },
+                "resolveSupport": {
+                    "properties": [
+                        "location.range"
+                    ]
+                }
+            },
+            "codeLens": {
+                "refreshSupport": true
+            },
+            "executeCommand": {
+                "dynamicRegistration": true
+            },
+            "configuration": true,
+            "workspaceFolders": true,
+            "semanticTokens": {
+                "refreshSupport": true
+            },
+            "fileOperations": {
+                "dynamicRegistration": true,
+                "didCreate": true,
+                "didRename": true,
+                "didDelete": true,
+                "willCreate": true,
+                "willRename": true,
+                "willDelete": true
+            },
+            "inlineValue": {
+                "refreshSupport": true
+            },
+            "inlayHint": {
+                "refreshSupport": true
+            },
+            "diagnostics": {
+                "refreshSupport": true
+            }
+        },
+        "textDocument": {
+            "publishDiagnostics": {
+                "relatedInformation": true,
+                "versionSupport": false,
+                "tagSupport": {
+                    "valueSet": [
+                        1,
+                        2
+                    ]
+                },
+                "codeDescriptionSupport": true,
+                "dataSupport": true
+            },
+            "synchronization": {
+                "dynamicRegistration": true,
+                "willSave": true,
+                "willSaveWaitUntil": true,
+                "didSave": true
+            },
+            "completion": {
+                "dynamicRegistration": true,
+                "contextSupport": true,
+                "completionItem": {
+                    "snippetSupport": false,
+                    "commitCharactersSupport": true,
+                    "documentationFormat": [
+                        "markdown",
+                        "plaintext"
+                    ],
+                    "deprecatedSupport": true,
+                    "preselectSupport": true,
+                    "tagSupport": {
+                        "valueSet": [
+                            1
+                        ]
+                    },
+                    "insertReplaceSupport": false,
+                    "resolveSupport": {
+                        "properties": [
+                            "documentation",
+                            "detail",
+                            "additionalTextEdits"
+                        ]
+                    },
+                    "insertTextModeSupport": {
+                        "valueSet": [
+                            1,
+                            2
+                        ]
+                    },
+                    "labelDetailsSupport": true
+                },
+                "insertTextMode": 2,
+                "completionItemKind": {
+                    "valueSet": [
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        8,
+                        9,
+                        10,
+                        11,
+                        12,
+                        13,
+                        14,
+                        15,
+                        16,
+                        17,
+                        18,
+                        19,
+                        20,
+                        21,
+                        22,
+                        23,
+                        24,
+                        25
+                    ]
+                },
+                "completionList": {
+                    "itemDefaults": [
+                        "commitCharacters",
+                        "editRange",
+                        "insertTextFormat",
+                        "insertTextMode"
+                    ]
+                }
+            },
+            "hover": {
+                "dynamicRegistration": true,
+                "contentFormat": [
+                    "markdown",
+                    "plaintext"
+                ]
+            },
+            "signatureHelp": {
+                "dynamicRegistration": true,
+                "signatureInformation": {
+                    "documentationFormat": [
+                        "markdown",
+                        "plaintext"
+                    ],
+                    "parameterInformation": {
+                        "labelOffsetSupport": true
+                    },
+                    "activeParameterSupport": true
+                },
+                "contextSupport": true
+            },
+            "definition": {
+                "dynamicRegistration": true,
+                "linkSupport": true
+            },
+            "references": {
+                "dynamicRegistration": true
+            },
+            "documentHighlight": {
+                "dynamicRegistration": true
+            },
+            "documentSymbol": {
+                "dynamicRegistration": true,
+                "symbolKind": {
+                    "valueSet": [
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        8,
+                        9,
+                        10,
+                        11,
+                        12,
+                        13,
+                        14,
+                        15,
+                        16,
+                        17,
+                        18,
+                        19,
+                        20,
+                        21,
+                        22,
+                        23,
+                        24,
+                        25,
+                        26
+                    ]
+                },
+                "hierarchicalDocumentSymbolSupport": true,
+                "tagSupport": {
+                    "valueSet": [
+                        1
+                    ]
+                },
+                "labelSupport": true
+            },
+            "codeAction": {
+                "dynamicRegistration": true,
+                "isPreferredSupport": true,
+                "disabledSupport": true,
+                "dataSupport": true,
+                "resolveSupport": {
+                    "properties": [
+                        "edit"
+                    ]
+                },
+                "codeActionLiteralSupport": {
+                    "codeActionKind": {
+                        "valueSet": [
+                            "",
+                            "quickfix",
+                            "refactor",
+                            "refactor.extract",
+                            "refactor.inline",
+                            "refactor.rewrite",
+                            "source",
+                            "source.organizeImports"
+                        ]
+                    }
+                },
+                "honorsChangeAnnotations": false
+            },
+            "codeLens": {
+                "dynamicRegistration": true
+            },
+            "formatting": {
+                "dynamicRegistration": true
+            },
+            "rangeFormatting": {
+                "dynamicRegistration": true
+            },
+            "onTypeFormatting": {
+                "dynamicRegistration": true
+            },
+            "rename": {
+                "dynamicRegistration": true,
+                "prepareSupport": true,
+                "prepareSupportDefaultBehavior": 1,
+                "honorsChangeAnnotations": true
+            },
+            "documentLink": {
+                "dynamicRegistration": true,
+                "tooltipSupport": true
+            },
+            "typeDefinition": {
+                "dynamicRegistration": true,
+                "linkSupport": true
+            },
+            "implementation": {
+                "dynamicRegistration": true,
+                "linkSupport": true
+            },
+            "colorProvider": {
+                "dynamicRegistration": true
+            },
+            "foldingRange": {
+                "dynamicRegistration": true,
+                "rangeLimit": 5000,
+                "lineFoldingOnly": true,
+                "foldingRangeKind": {
+                    "valueSet": [
+                        "comment",
+                        "imports",
+                        "region"
+                    ]
+                },
+                "foldingRange": {
+                    "collapsedText": false
+                }
+            },
+            "declaration": {
+                "dynamicRegistration": true,
+                "linkSupport": true
+            },
+            "selectionRange": {
+                "dynamicRegistration": true
+            },
+            "callHierarchy": {
+                "dynamicRegistration": true
+            },
+            "semanticTokens": {
+                "dynamicRegistration": true,
+                "tokenTypes": [
+                    "namespace",
+                    "type",
+                    "class",
+                    "enum",
+                    "interface",
+                    "struct",
+                    "typeParameter",
+                    "parameter",
+                    "variable",
+                    "property",
+                    "enumMember",
+                    "event",
+                    "function",
+                    "method",
+                    "macro",
+                    "keyword",
+                    "modifier",
+                    "comment",
+                    "string",
+                    "number",
+                    "regexp",
+                    "operator",
+                    "decorator"
+                ],
+                "tokenModifiers": [
+                    "declaration",
+                    "definition",
+                    "readonly",
+                    "static",
+                    "deprecated",
+                    "abstract",
+                    "async",
+                    "modification",
+                    "documentation",
+                    "defaultLibrary"
+                ],
+                "formats": [
+                    "relative"
+                ],
+                "requests": {
+                    "range": true,
+                    "full": {
+                        "delta": true
+                    }
+                },
+                "multilineTokenSupport": false,
+                "overlappingTokenSupport": false,
+                "serverCancelSupport": true,
+                "augmentsSyntaxTokens": true
+            },
+            "linkedEditingRange": {
+                "dynamicRegistration": true
+            },
+            "typeHierarchy": {
+                "dynamicRegistration": true
+            },
+            "inlineValue": {
+                "dynamicRegistration": true
+            },
+            "inlayHint": {
+                "dynamicRegistration": true,
+                "resolveSupport": {
+                    "properties": [
+                        "tooltip",
+                        "textEdits",
+                        "label.tooltip",
+                        "label.location",
+                        "label.command"
+                    ]
+                }
+            },
+            "diagnostic": {
+                "dynamicRegistration": true,
+                "relatedDocumentSupport": false
+            }
+        },
+        "window": {
+            "showMessage": {
+                "messageActionItem": {
+                    "additionalPropertiesSupport": true
+                }
+            },
+            "showDocument": {
+                "support": true
+            },
+            "workDoneProgress": true
+        },
+        "general": {
+            "staleRequestSupport": {
+                "cancel": true,
+                "retryOnContentModified": [
+                    "textDocument/semanticTokens/full",
+                    "textDocument/semanticTokens/range",
+                    "textDocument/semanticTokens/full/delta"
+                ]
+            },
+            "regularExpressions": {
+                "engine": "ECMAScript",
+                "version": "ES2020"
+            },
+            "markdown": {
+                "parser": "marked",
+                "version": "1.1.0"
+            },
+            "positionEncodings": [
+                "utf-16"
+            ]
+        },
+        "notebookDocument": {
+            "synchronization": {
+                "dynamicRegistration": true,
+                "executionSummarySupport": true
+            }
+        }
+    },
+    "initializationOptions": {
+        "bundles": [
+            "intellicode-core.jar"
+        ],
+        "workspaceFolders": "[pathlib.Path(repository_absolute_path).as_uri()]",
+        "settings": {
+            "java": {
+                "home": null,
+                "jdt": {
+                    "ls": {
+                        "java": {
+                            "home": null
+                        },
+                        "vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m -Xlog:disable",
+                        "lombokSupport": {
+                            "enabled": true
+                        },
+                        "protobufSupport": {
+                            "enabled": true
+                        },
+                        "androidSupport": {
+                            "enabled": true
+                        }
+                    }
+                },
+                "errors": {
+                    "incompleteClasspath": {
+                        "severity": "error"
+                    }
+                },
+                "configuration": {
+                    "checkProjectSettingsExclusions": false,
+                    "updateBuildConfiguration": "interactive",
+                    "maven": {
+                        "userSettings": null,
+                        "globalSettings": null,
+                        "notCoveredPluginExecutionSeverity": "warning",
+                        "defaultMojoExecutionAction": "ignore"
+                    },
+                    "workspaceCacheLimit": 90,
+                    "runtimes": [
+                        {
+                            "name": "JavaSE-17",
+                            "path": "static/vscode-java/extension/jre/17.0.8.1-linux-x86_64",
+                            "default": true
+                        }
+                    ]
+                },
+                "trace": {
+                    "server": "verbose"
+                },
+                "import": {
+                    "maven": {
+                        "enabled": true,
+                        "offline": {
+                            "enabled": false
+                        },
+                        "disableTestClasspathFlag": false
+                    },
+                    "gradle": {
+                        "enabled": true,
+                        "wrapper": {
+                            "enabled": true
+                        },
+                        "version": null,
+                        "home": "abs(static/gradle-7.3.3)",
+                        "java": {
+                            "home": "abs(static/launch_jres/17.0.6-linux-x86_64)"
+                        },
+                        "offline": {
+                            "enabled": false
+                        },
+                        "arguments": null,
+                        "jvmArguments": null,
+                        "user": {
+                            "home": null
+                        },
+                        "annotationProcessing": {
+                            "enabled": true
+                        }
+                    },
+                    "exclusions": [
+                        "**/node_modules/**",
+                        "**/.metadata/**",
+                        "**/archetype-resources/**",
+                        "**/META-INF/maven/**"
+                    ],
+                    "generatesMetadataFilesAtProjectRoot": false
+                },
+                "maven": {
+                    "downloadSources": true,
+                    "updateSnapshots": true
+                },
+                "eclipse": {
+                    "downloadSources": true
+                },
+                "referencesCodeLens": {
+                    "enabled": true
+                },
+                "signatureHelp": {
+                    "enabled": true,
+                    "description": {
+                        "enabled": true
+                    }
+                },
+                "implementationsCodeLens": {
+                    "enabled": true
+                },
+                "format": {
+                    "enabled": true,
+                    "settings": {
+                        "url": null,
+                        "profile": null
+                    },
+                    "comments": {
+                        "enabled": true
+                    },
+                    "onType": {
+                        "enabled": true
+                    },
+                    "insertSpaces": true,
+                    "tabSize": 4
+                },
+                "saveActions": {
+                    "organizeImports": false
+                },
+                "project": {
+                    "referencedLibraries": [
+                        "lib/**/*.jar"
+                    ],
+                    "importOnFirstTimeStartup": "automatic",
+                    "importHint": true,
+                    "resourceFilters": [
+                        "node_modules",
+                        "\\.git"
+                    ],
+                    "encoding": "ignore",
+                    "exportJar": {
+                        "targetPath": "${workspaceFolder}/${workspaceFolderBasename}.jar"
+                    }
+                },
+                "contentProvider": {
+                    "preferred": null
+                },
+                "autobuild": {
+                    "enabled": true
+                },
+                "maxConcurrentBuilds": 1,
+                "recommendations": {
+                    "dependency": {
+                        "analytics": {
+                            "show": true
+                        }
+                    }
+                },
+                "completion": {
+                    "maxResults": 0,
+                    "enabled": true,
+                    "guessMethodArguments": true,
+                    "favoriteStaticMembers": [
+                        "org.junit.Assert.*",
+                        "org.junit.Assume.*",
+                        "org.junit.jupiter.api.Assertions.*",
+                        "org.junit.jupiter.api.Assumptions.*",
+                        "org.junit.jupiter.api.DynamicContainer.*",
+                        "org.junit.jupiter.api.DynamicTest.*",
+                        "org.mockito.Mockito.*",
+                        "org.mockito.ArgumentMatchers.*",
+                        "org.mockito.Answers.*"
+                    ],
+                    "filteredTypes": [
+                        "java.awt.*",
+                        "com.sun.*",
+                        "sun.*",
+                        "jdk.*",
+                        "org.graalvm.*",
+                        "io.micrometer.shaded.*"
+                    ],
+                    "importOrder": [
+                        "#",
+                        "java",
+                        "javax",
+                        "org",
+                        "com",
+                        ""
+                    ],
+                    "postfix": {
+                        "enabled": false
+                    },
+                    "matchCase": "off"
+                },
+                "foldingRange": {
+                    "enabled": true
+                },
+                "progressReports": {
+                    "enabled": false
+                },
+                "codeGeneration": {
+                    "hashCodeEquals": {
+                        "useJava7Objects": false,
+                        "useInstanceof": false
+                    },
+                    "useBlocks": false,
+                    "generateComments": false,
+                    "toString": {
+                        "template": "${object.className} [${member.name()}=${member.value}, ${otherMembers}]",
+                        "codeStyle": "STRING_CONCATENATION",
+                        "skipNullValues": false,
+                        "listArrayContents": true,
+                        "limitElements": 0
+                    },
+                    "insertionLocation": "afterCursor"
+                },
+                "selectionRange": {
+                    "enabled": true
+                },
+                "showBuildStatusOnStart": {
+                    "enabled": "notification"
+                },
+                "server": {
+                    "launchMode": "Standard"
+                },
+                "sources": {
+                    "organizeImports": {
+                        "starThreshold": 99,
+                        "staticStarThreshold": 99
+                    }
+                },
+                "imports": {
+                    "gradle": {
+                        "wrapper": {
+                            "checksums": []
+                        }
+                    }
+                },
+                "templates": {
+                    "fileHeader": [],
+                    "typeComment": []
+                },
+                "references": {
+                    "includeAccessors": true,
+                    "includeDecompiledSources": true
+                },
+                "typeHierarchy": {
+                    "lazyLoad": false
+                },
+                "settings": {
+                    "url": null
+                },
+                "symbols": {
+                    "includeSourceMethodDeclarations": false
+                },
+                "quickfix": {
+                    "showAt": "line"
+                },
+                "inlayHints": {
+                    "parameterNames": {
+                        "enabled": "literals",
+                        "exclusions": []
+                    }
+                },
+                "codeAction": {
+                    "sortMembers": {
+                        "avoidVolatileChanges": true
+                    }
+                },
+                "compile": {
+                    "nullAnalysis": {
+                        "nonnull": [
+                            "javax.annotation.Nonnull",
+                            "org.eclipse.jdt.annotation.NonNull",
+                            "org.springframework.lang.NonNull"
+                        ],
+                        "nullable": [
+                            "javax.annotation.Nullable",
+                            "org.eclipse.jdt.annotation.Nullable",
+                            "org.springframework.lang.Nullable"
+                        ],
+                        "mode": "automatic"
+                    }
+                },
+                "cleanup": {
+                    "actionsOnSave": []
+                },
+                "sharedIndexes": {
+                    "enabled": "auto",
+                    "location": ""
+                },
+                "refactoring": {
+                    "extract": {
+                        "interface": {
+                            "replace": true
+                        }
+                    }
+                },
+                "debug": {
+                    "logLevel": "verbose",
+                    "settings": {
+                        "showHex": false,
+                        "showStaticVariables": false,
+                        "showQualifiedNames": false,
+                        "showLogicalStructure": true,
+                        "showToString": true,
+                        "maxStringLength": 0,
+                        "numericPrecision": 0,
+                        "hotCodeReplace": "manual",
+                        "enableRunDebugCodeLens": true,
+                        "forceBuildBeforeLaunch": true,
+                        "onBuildFailureProceed": false,
+                        "console": "integratedTerminal",
+                        "exceptionBreakpoint": {
+                            "skipClasses": []
+                        },
+                        "stepping": {
+                            "skipClasses": [],
+                            "skipSynthetics": false,
+                            "skipStaticInitializers": false,
+                            "skipConstructors": false
+                        },
+                        "jdwp": {
+                            "limitOfVariablesPerJdwpRequest": 100,
+                            "requestTimeout": 3000,
+                            "async": "auto"
+                        },
+                        "vmArgs": ""
+                    }
+                },
+                "silentNotification": false,
+                "dependency": {
+                    "showMembers": false,
+                    "syncWithFolderExplorer": true,
+                    "autoRefresh": true,
+                    "refreshDelay": 2000,
+                    "packagePresentation": "flat"
+                },
+                "help": {
+                    "firstView": "auto",
+                    "showReleaseNotes": true,
+                    "collectErrorLog": false
+                },
+                "test": {
+                    "defaultConfig": "",
+                    "config": {}
+                }
+            }
+        },
+        "extendedClientCapabilities": {
+            "progressReportProvider": false,
+            "classFileContentsSupport": true,
+            "overrideMethodsPromptSupport": true,
+            "hashCodeEqualsPromptSupport": true,
+            "advancedOrganizeImportsSupport": true,
+            "generateToStringPromptSupport": true,
+            "advancedGenerateAccessorsSupport": true,
+            "generateConstructorsPromptSupport": true,
+            "generateDelegateMethodsPromptSupport": true,
+            "advancedExtractRefactoringSupport": true,
+            "inferSelectionSupport": [
+                "extractMethod",
+                "extractVariable",
+                "extractField"
+            ],
+            "moveRefactoringSupport": true,
+            "clientHoverProvider": true,
+            "clientDocumentSymbolProvider": true,
+            "gradleChecksumWrapperPromptSupport": true,
+            "resolveAdditionalTextEditsSupport": true,
+            "advancedIntroduceParameterRefactoringSupport": true,
+            "actionableRuntimeNotificationSupport": true,
+            "shouldLanguageServerExitOnShutdown": true,
+            "onCompletionItemSelectedCommand": "editor.action.triggerParameterHints",
+            "extractInterfaceSupport": true,
+            "advancedUpgradeGradleSupport": true
+        },
+        "triggerFiles": []
+    },
+    "trace": "verbose",
+    "workspaceFolders": "[\n            {\n                \"uri\": pathlib.Path(repository_absolute_path).as_uri(),\n                \"name\": os.path.basename(repository_absolute_path),\n            }\n        ]"
+}

--- a/src/multilspy/language_servers/kotlin_language_server/initialize_params.json
+++ b/src/multilspy/language_servers/kotlin_language_server/initialize_params.json
@@ -2,8 +2,8 @@
     "_description": "The parameters sent by the client when initializing the language server with the \"initialize\" request. More details at https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize",
     "processId": "os.getpid()",
     "clientInfo": {
-        "name": "Visual Studio Code - Insiders",
-        "version": "1.77.0-insider"
+        "name": "Multilspy Kotlin Client",
+        "version": "1.0.0"
     },
     "locale": "en",
     "rootPath": "repository_absolute_path",
@@ -469,380 +469,52 @@
         }
     },
     "initializationOptions": {
-        "bundles": [
-            "intellicode-core.jar"
-        ],
         "workspaceFolders": "[pathlib.Path(repository_absolute_path).as_uri()]",
-        "settings": {
-            "java": {
-                "home": null,
-                "jdt": {
-                    "ls": {
-                        "java": {
-                            "home": null
-                        },
-                        "vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m -Xlog:disable",
-                        "lombokSupport": {
-                            "enabled": true
-                        },
-                        "protobufSupport": {
-                            "enabled": true
-                        },
-                        "androidSupport": {
-                            "enabled": true
-                        }
-                    }
-                },
-                "errors": {
-                    "incompleteClasspath": {
-                        "severity": "error"
-                    }
-                },
-                "configuration": {
-                    "checkProjectSettingsExclusions": false,
-                    "updateBuildConfiguration": "interactive",
-                    "maven": {
-                        "userSettings": null,
-                        "globalSettings": null,
-                        "notCoveredPluginExecutionSeverity": "warning",
-                        "defaultMojoExecutionAction": "ignore"
-                    },
-                    "workspaceCacheLimit": 90,
-                    "runtimes": [
-                        {
-                            "name": "JavaSE-17",
-                            "path": "static/vscode-java/extension/jre/17.0.8.1-linux-x86_64",
-                            "default": true
-                        }
-                    ]
-                },
-                "trace": {
-                    "server": "verbose"
-                },
-                "import": {
-                    "maven": {
-                        "enabled": true,
-                        "offline": {
-                            "enabled": false
-                        },
-                        "disableTestClasspathFlag": false
-                    },
-                    "gradle": {
-                        "enabled": true,
-                        "wrapper": {
-                            "enabled": true
-                        },
-                        "version": null,
-                        "home": "abs(static/gradle-7.3.3)",
-                        "java": {
-                            "home": "abs(static/launch_jres/17.0.6-linux-x86_64)"
-                        },
-                        "offline": {
-                            "enabled": false
-                        },
-                        "arguments": null,
-                        "jvmArguments": null,
-                        "user": {
-                            "home": null
-                        },
-                        "annotationProcessing": {
-                            "enabled": true
-                        }
-                    },
-                    "exclusions": [
-                        "**/node_modules/**",
-                        "**/.metadata/**",
-                        "**/archetype-resources/**",
-                        "**/META-INF/maven/**"
-                    ],
-                    "generatesMetadataFilesAtProjectRoot": false
-                },
-                "maven": {
-                    "downloadSources": true,
-                    "updateSnapshots": true
-                },
-                "eclipse": {
-                    "downloadSources": true
-                },
-                "referencesCodeLens": {
-                    "enabled": true
-                },
-                "signatureHelp": {
-                    "enabled": true,
-                    "description": {
-                        "enabled": true
-                    }
-                },
-                "implementationsCodeLens": {
-                    "enabled": true
-                },
-                "format": {
-                    "enabled": true,
-                    "settings": {
-                        "url": null,
-                        "profile": null
-                    },
-                    "comments": {
-                        "enabled": true
-                    },
-                    "onType": {
-                        "enabled": true
-                    },
-                    "insertSpaces": true,
-                    "tabSize": 4
-                },
-                "saveActions": {
-                    "organizeImports": false
-                },
-                "project": {
-                    "referencedLibraries": [
-                        "lib/**/*.jar"
-                    ],
-                    "importOnFirstTimeStartup": "automatic",
-                    "importHint": true,
-                    "resourceFilters": [
-                        "node_modules",
-                        "\\.git"
-                    ],
-                    "encoding": "ignore",
-                    "exportJar": {
-                        "targetPath": "${workspaceFolder}/${workspaceFolderBasename}.jar"
-                    }
-                },
-                "contentProvider": {
-                    "preferred": null
-                },
-                "autobuild": {
-                    "enabled": true
-                },
-                "maxConcurrentBuilds": 1,
-                "recommendations": {
-                    "dependency": {
-                        "analytics": {
-                            "show": true
-                        }
-                    }
-                },
-                "completion": {
-                    "maxResults": 0,
-                    "enabled": true,
-                    "guessMethodArguments": true,
-                    "favoriteStaticMembers": [
-                        "org.junit.Assert.*",
-                        "org.junit.Assume.*",
-                        "org.junit.jupiter.api.Assertions.*",
-                        "org.junit.jupiter.api.Assumptions.*",
-                        "org.junit.jupiter.api.DynamicContainer.*",
-                        "org.junit.jupiter.api.DynamicTest.*",
-                        "org.mockito.Mockito.*",
-                        "org.mockito.ArgumentMatchers.*",
-                        "org.mockito.Answers.*"
-                    ],
-                    "filteredTypes": [
-                        "java.awt.*",
-                        "com.sun.*",
-                        "sun.*",
-                        "jdk.*",
-                        "org.graalvm.*",
-                        "io.micrometer.shaded.*"
-                    ],
-                    "importOrder": [
-                        "#",
-                        "java",
-                        "javax",
-                        "org",
-                        "com",
-                        ""
-                    ],
-                    "postfix": {
-                        "enabled": false
-                    },
-                    "matchCase": "off"
-                },
-                "foldingRange": {
-                    "enabled": true
-                },
-                "progressReports": {
-                    "enabled": false
-                },
-                "codeGeneration": {
-                    "hashCodeEquals": {
-                        "useJava7Objects": false,
-                        "useInstanceof": false
-                    },
-                    "useBlocks": false,
-                    "generateComments": false,
-                    "toString": {
-                        "template": "${object.className} [${member.name()}=${member.value}, ${otherMembers}]",
-                        "codeStyle": "STRING_CONCATENATION",
-                        "skipNullValues": false,
-                        "listArrayContents": true,
-                        "limitElements": 0
-                    },
-                    "insertionLocation": "afterCursor"
-                },
-                "selectionRange": {
-                    "enabled": true
-                },
-                "showBuildStatusOnStart": {
-                    "enabled": "notification"
-                },
-                "server": {
-                    "launchMode": "Standard"
-                },
-                "sources": {
-                    "organizeImports": {
-                        "starThreshold": 99,
-                        "staticStarThreshold": 99
-                    }
-                },
-                "imports": {
-                    "gradle": {
-                        "wrapper": {
-                            "checksums": []
-                        }
-                    }
-                },
-                "templates": {
-                    "fileHeader": [],
-                    "typeComment": []
-                },
-                "references": {
-                    "includeAccessors": true,
-                    "includeDecompiledSources": true
-                },
-                "typeHierarchy": {
-                    "lazyLoad": false
-                },
-                "settings": {
-                    "url": null
-                },
-                "symbols": {
-                    "includeSourceMethodDeclarations": false
-                },
-                "quickfix": {
-                    "showAt": "line"
-                },
-                "inlayHints": {
-                    "parameterNames": {
-                        "enabled": "literals",
-                        "exclusions": []
-                    }
-                },
-                "codeAction": {
-                    "sortMembers": {
-                        "avoidVolatileChanges": true
-                    }
-                },
-                "compile": {
-                    "nullAnalysis": {
-                        "nonnull": [
-                            "javax.annotation.Nonnull",
-                            "org.eclipse.jdt.annotation.NonNull",
-                            "org.springframework.lang.NonNull"
-                        ],
-                        "nullable": [
-                            "javax.annotation.Nullable",
-                            "org.eclipse.jdt.annotation.Nullable",
-                            "org.springframework.lang.Nullable"
-                        ],
-                        "mode": "automatic"
-                    }
-                },
-                "cleanup": {
-                    "actionsOnSave": []
-                },
-                "sharedIndexes": {
-                    "enabled": "auto",
-                    "location": ""
-                },
-                "refactoring": {
-                    "extract": {
-                        "interface": {
-                            "replace": true
-                        }
-                    }
-                },
-                "debug": {
-                    "logLevel": "verbose",
-                    "settings": {
-                        "showHex": false,
-                        "showStaticVariables": false,
-                        "showQualifiedNames": false,
-                        "showLogicalStructure": true,
-                        "showToString": true,
-                        "maxStringLength": 0,
-                        "numericPrecision": 0,
-                        "hotCodeReplace": "manual",
-                        "enableRunDebugCodeLens": true,
-                        "forceBuildBeforeLaunch": true,
-                        "onBuildFailureProceed": false,
-                        "console": "integratedTerminal",
-                        "exceptionBreakpoint": {
-                            "skipClasses": []
-                        },
-                        "stepping": {
-                            "skipClasses": [],
-                            "skipSynthetics": false,
-                            "skipStaticInitializers": false,
-                            "skipConstructors": false
-                        },
-                        "jdwp": {
-                            "limitOfVariablesPerJdwpRequest": 100,
-                            "requestTimeout": 3000,
-                            "async": "auto"
-                        },
-                        "vmArgs": ""
-                    }
-                },
-                "silentNotification": false,
-                "dependency": {
-                    "showMembers": false,
-                    "syncWithFolderExplorer": true,
-                    "autoRefresh": true,
-                    "refreshDelay": 2000,
-                    "packagePresentation": "flat"
-                },
-                "help": {
-                    "firstView": "auto",
-                    "showReleaseNotes": true,
-                    "collectErrorLog": false
-                },
-                "test": {
-                    "defaultConfig": "",
-                    "config": {}
-                }
+        "storagePath": null,
+        "codegen": {
+            "enabled": false
+        },
+        "compiler": {
+            "jvm": {
+                "target": "default"
             }
         },
-        "extendedClientCapabilities": {
-            "progressReportProvider": false,
-            "classFileContentsSupport": true,
-            "overrideMethodsPromptSupport": true,
-            "hashCodeEqualsPromptSupport": true,
-            "advancedOrganizeImportsSupport": true,
-            "generateToStringPromptSupport": true,
-            "advancedGenerateAccessorsSupport": true,
-            "generateConstructorsPromptSupport": true,
-            "generateDelegateMethodsPromptSupport": true,
-            "advancedExtractRefactoringSupport": true,
-            "inferSelectionSupport": [
-                "extractMethod",
-                "extractVariable",
-                "extractField"
-            ],
-            "moveRefactoringSupport": true,
-            "clientHoverProvider": true,
-            "clientDocumentSymbolProvider": true,
-            "gradleChecksumWrapperPromptSupport": true,
-            "resolveAdditionalTextEditsSupport": true,
-            "advancedIntroduceParameterRefactoringSupport": true,
-            "actionableRuntimeNotificationSupport": true,
-            "shouldLanguageServerExitOnShutdown": true,
-            "onCompletionItemSelectedCommand": "editor.action.triggerParameterHints",
-            "extractInterfaceSupport": true,
-            "advancedUpgradeGradleSupport": true
+        "completion": {
+            "snippets": {
+                "enabled": true
+            }
         },
-        "triggerFiles": []
+        "diagnostics": {
+            "enabled": true,
+            "level": 4,
+            "debounceTime": 250
+        },
+        "scripts": {
+            "enabled": true,
+            "buildScriptsEnabled": true
+        },
+        "indexing": {
+            "enabled": true
+        },
+        "externalSources": {
+            "useKlsScheme": false,
+            "autoConvertToKotlin": false
+        },
+        "inlayHints": {
+            "typeHints": false,
+            "parameterHints": false,
+            "chainedHints": false
+        },
+        "formatting": {
+            "formatter": "ktfmt",
+            "ktfmt": {
+                "style": "google",
+                "indent": 4,
+                "maxWidth": 100,
+                "continuationIndent": 8,
+                "removeUnusedImports": true
+            }
+        }
     },
     "trace": "verbose",
     "workspaceFolders": "[\n            {\n                \"uri\": pathlib.Path(repository_absolute_path).as_uri(),\n                \"name\": os.path.basename(repository_absolute_path),\n            }\n        ]"

--- a/src/multilspy/language_servers/kotlin_language_server/kotlin_language_server.py
+++ b/src/multilspy/language_servers/kotlin_language_server/kotlin_language_server.py
@@ -1,0 +1,175 @@
+"""
+Provides Kotlin specific instantiation of the LanguageServer class. Contains various configurations and settings specific to Kotlin.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import stat
+import pathlib
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+from multilspy.multilspy_logger import MultilspyLogger
+from multilspy.language_server import LanguageServer
+from multilspy.lsp_protocol_handler.server import ProcessLaunchInfo
+from multilspy.lsp_protocol_handler.lsp_types import InitializeParams
+from multilspy.multilspy_config import MultilspyConfig
+from multilspy.multilspy_utils import FileUtils
+from multilspy.multilspy_utils import PlatformUtils
+
+
+class KotlinLanguageServer(LanguageServer):
+    """
+    Provides Kotlin specific instantiation of the LanguageServer class. Contains various configurations and settings specific to Kotlin.
+    """
+
+    def __init__(self, config: MultilspyConfig, logger: MultilspyLogger, repository_root_path: str):
+        """
+        Creates a JediServer instance. This class is not meant to be instantiated directly. Use LanguageServer.create() instead.
+        """
+        kotlin_executable_path = self.setup_runtime_dependencies(logger, config)
+        super().__init__(
+            config,
+            logger,
+            repository_root_path,
+            ProcessLaunchInfo(cmd=kotlin_executable_path, cwd=repository_root_path),
+            "kotlin",
+        )
+        self.server_ready = asyncio.Event()
+
+    def setup_runtime_dependencies(self, logger: MultilspyLogger, config: MultilspyConfig) -> str:
+        """
+        Setup runtime dependencies for Kotlin Language Server.
+        """
+        platform_id = PlatformUtils.get_platform_id()
+
+        with open(os.path.join(os.path.dirname(__file__), "runtime_dependencies.json"), "r") as f:
+            d = json.load(f)
+            del d["_description"]
+
+        assert platform_id.value in [
+            "linux-x64",
+            "win-x64",
+        ], "Only linux-x64 and win-x64 platform is supported for in multilspy at the moment"
+
+        runtime_dependencies = d["runtimeDependencies"]
+        runtime_dependencies = [
+            dependency for dependency in runtime_dependencies if dependency["platformId"] == platform_id.value
+        ]
+        assert len(runtime_dependencies) == 1
+        dependency = runtime_dependencies[0]
+
+        kotlin_ls_dir = os.path.join(os.path.dirname(__file__), "static")
+        kotlin_executable_path = os.path.join(kotlin_ls_dir, "server", "bin", dependency["binaryName"])
+        if not os.path.exists(kotlin_ls_dir):
+            os.makedirs(kotlin_ls_dir)
+            FileUtils.download_and_extract_archive(
+                logger, dependency["url"], kotlin_ls_dir, dependency["archiveType"]
+            )
+        assert os.path.exists(kotlin_executable_path)
+        os.chmod(kotlin_executable_path, stat.S_IEXEC)
+
+        return kotlin_executable_path
+
+    def _get_initialize_params(self, repository_absolute_path: str) -> InitializeParams:
+        """
+        Returns the initialize params for the Kotlin Language Server.
+        """
+        with open(str(pathlib.PurePath(os.path.dirname(__file__), "initialize_params.json")), "r") as f:
+            d: InitializeParams = json.load(f)
+
+        del d["_description"]
+
+        if not os.path.isabs(repository_absolute_path):
+            repository_absolute_path = os.path.abspath(repository_absolute_path)
+
+        assert d["processId"] == "os.getpid()"
+        d["processId"] = os.getpid()
+
+        assert d["rootPath"] == "repository_absolute_path"
+        d["rootPath"] = repository_absolute_path
+
+        assert d["rootUri"] == "pathlib.Path(repository_absolute_path).as_uri()"
+        d["rootUri"] = pathlib.Path(repository_absolute_path).as_uri()
+
+        assert d["initializationOptions"]["workspaceFolders"] == "[pathlib.Path(repository_absolute_path).as_uri()]"
+        d["initializationOptions"]["workspaceFolders"] = [pathlib.Path(repository_absolute_path).as_uri()]
+
+        assert (
+                d["workspaceFolders"]
+                == '[\n            {\n                "uri": pathlib.Path(repository_absolute_path).as_uri(),\n                "name": os.path.basename(repository_absolute_path),\n            }\n        ]'
+        )
+        d["workspaceFolders"] = [
+            {
+                "uri": pathlib.Path(repository_absolute_path).as_uri(),
+                "name": os.path.basename(repository_absolute_path),
+            }
+        ]
+
+        return d
+
+    @asynccontextmanager
+    async def start_server(self) -> AsyncIterator["KotlinLanguageServer"]:
+        """
+        Starts the Kotlin Language Server, waits for the server to be ready and yields the LanguageServer instance.
+
+        Usage:
+        ```
+        async with lsp.start_server():
+            # LanguageServer has been initialized and ready to serve requests
+            await lsp.request_definition(...)
+            await lsp.request_references(...)
+            # Shutdown the LanguageServer on exit from scope
+        # LanguageServer has been shutdown
+        """
+
+        async def register_capability_handler(params):
+            assert "registrations" in params
+            for registration in params["registrations"]:
+                if registration["method"] == "workspace/executeCommand":
+                    self.initialize_searcher_command_available.set()
+            return
+
+        async def execute_client_command_handler(params):
+            return []
+
+        async def do_nothing(params):
+            return
+
+        async def window_log_message(msg):
+            self.logger.log(f"LSP: window/logMessage: {msg}", logging.INFO)
+
+        self.server.on_request("client/registerCapability", register_capability_handler)
+        self.server.on_notification("language/status", do_nothing)
+        self.server.on_notification("window/logMessage", window_log_message)
+        self.server.on_request("workspace/executeClientCommand", execute_client_command_handler)
+        self.server.on_notification("$/progress", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("language/actionableNotification", do_nothing)
+        # self.server.on_notification("experimental/serverStatus", check_experimental_status)
+
+        async with super().start_server():
+            self.logger.log("Starting Kotlin server process", logging.INFO)
+            await self.server.start()
+            initialize_params = self._get_initialize_params(self.repository_root_path)
+
+            self.logger.log(
+                "Sending initialize request from LSP client to LSP server and awaiting response",
+                logging.INFO,
+            )
+            init_response = await self.server.send.initialize(initialize_params)
+
+            
+            self.server.notify.initialized({})
+            self.completions_available.set()
+
+            # Kotlin server is typically ready immediately after initialization
+            self.server_ready.set()
+            await self.server_ready.wait()
+
+            yield self
+
+            await self.server.shutdown()
+            await self.server.stop()

--- a/src/multilspy/language_servers/kotlin_language_server/runtime_dependencies.json
+++ b/src/multilspy/language_servers/kotlin_language_server/runtime_dependencies.json
@@ -1,13 +1,9 @@
 {
-    "_description": "Used to download the runtime dependencies for running RustAnalyzer. Obtained from https://github.com/rust-lang/rust-analyzer/releases",
-    "runtimeDependencies": [
-        {
-            "id": "KotlinLsp",
-            "description": "KotlinLsp",
-            "url": "https://github.com/fwcd/kotlin-language-server/releases/download/1.3.13/server.zip",
-            "platformId": "win-x64",
-            "archiveType": "zip",
-            "binaryName": "kotlin-language-server.bat"
-        }
-    ]
+    "_description": "Used to download the runtime dependencies for Kotlin Language Server from https://github.com/fwcd/kotlin-language-server",
+    "runtimeDependency": {
+        "id": "KotlinLsp",
+        "description": "Kotlin Language Server",
+        "url": "https://github.com/fwcd/kotlin-language-server/releases/download/1.3.13/server.zip",
+        "archiveType": "zip"
+    }
 }

--- a/src/multilspy/language_servers/kotlin_language_server/runtime_dependencies.json
+++ b/src/multilspy/language_servers/kotlin_language_server/runtime_dependencies.json
@@ -1,0 +1,13 @@
+{
+    "_description": "Used to download the runtime dependencies for running RustAnalyzer. Obtained from https://github.com/rust-lang/rust-analyzer/releases",
+    "runtimeDependencies": [
+        {
+            "id": "KotlinLsp",
+            "description": "KotlinLsp",
+            "url": "https://github.com/fwcd/kotlin-language-server/releases/download/1.3.13/server.zip",
+            "platformId": "win-x64",
+            "archiveType": "zip",
+            "binaryName": "kotlin-language-server.bat"
+        }
+    ]
+}

--- a/src/multilspy/multilspy_config.py
+++ b/src/multilspy/multilspy_config.py
@@ -14,6 +14,7 @@ class Language(str, Enum):
     PYTHON = "python"
     RUST = "rust"
     JAVA = "java"
+    KOTLIN = "kotlin"
     TYPESCRIPT = "typescript"
     JAVASCRIPT = "javascript"
     GO = "go"

--- a/tests/multilspy/test_multilspy_kotlin.py
+++ b/tests/multilspy/test_multilspy_kotlin.py
@@ -1,0 +1,31 @@
+"""
+This file contains tests for running the Java Language Server: Eclipse JDT.LS
+"""
+
+import pytest
+from pathlib import PurePath
+from multilspy import LanguageServer
+from multilspy.multilspy_config import Language
+from multilspy.multilspy_types import Position, CompletionItemKind
+from tests.test_utils import create_test_context
+
+pytest_plugins = ("pytest_asyncio",)
+
+@pytest.mark.asyncio
+async def test_multilspy_kotlin_example_repo_document_symbols() -> None:
+    code_language = Language.KOTLIN
+    params = {
+        "code_language": code_language,
+        "repo_url": "https://github.com/LakshyAAAgrawal/ExampleRepo/",
+        "repo_commit": "f3762fd55a457ff9c6b0bf3b266de2b203a766ab",
+    }
+    with create_test_context(params) as context:
+        lsp = LanguageServer.create(context.config, context.logger, context.source_directory)
+
+        # All the communication with the language server must be performed inside the context manager
+        # The server process is started when the context manager is entered and is terminated when the context manager is exited.
+        async with lsp.start_server():
+            filepath = str(PurePath("Person.java"))
+            result = await lsp.request_document_symbols(filepath)
+
+            print(result)

--- a/tests/multilspy/test_sync_multilspy_kotlin.py
+++ b/tests/multilspy/test_sync_multilspy_kotlin.py
@@ -1,30 +1,29 @@
 """
 This file contains tests for running the Kotlin Language Server: kotlin-language-server
+using the synchronous API
 """
 
-import pytest
 from pathlib import PurePath
-
-from multilspy import LanguageServer
+from multilspy import SyncLanguageServer
 from multilspy.multilspy_config import Language
 from tests.test_utils import create_test_context
 
-pytest_plugins = ("pytest_asyncio",)
-
-@pytest.mark.asyncio
-async def test_document_symbols() -> None:
+def test_sync_document_symbols() -> None:
+    """
+    Test document symbols functionality using the sync API
+    """
     params = {
         "code_language": Language.KOTLIN,
         "repo_url": "https://github.com/fwcd/kotlin-language-server/",
         "repo_commit": "8418fb560a4013c3e02c942797e9c877affa0a51"
     }
     with create_test_context(params) as context:
-        lsp = LanguageServer.create(context.config, context.logger, context.source_directory)
+        lsp = SyncLanguageServer.create(context.config, context.logger, context.source_directory)
         test_file = str(PurePath("server/src/test/resources/symbols/DocumentSymbols.kt"))
 
-        async with lsp.start_server():
+        with lsp.start_server():
             with lsp.open_file(test_file):
-                result = await lsp.request_document_symbols(test_file)
+                result = lsp.request_document_symbols(test_file)
                 
                 symbols = result[0]
                 assert len(symbols) == 5, "Should find exactly 5 document symbols"
@@ -48,20 +47,22 @@ async def test_document_symbols() -> None:
                 companion_symbols = [s for s in symbols if s["name"] == "DocumentSymbols" and s["kind"] == 9]
                 assert len(companion_symbols) == 2, "Should find exactly 2 companion object symbols"
 
-@pytest.mark.asyncio
-async def test_definition() -> None:
+def test_sync_definition() -> None:
+    """
+    Test definition lookup functionality using the sync API
+    """
     params = {
         "code_language": Language.KOTLIN,
         "repo_url": "https://github.com/fwcd/kotlin-language-server/",
         "repo_commit": "8418fb560a4013c3e02c942797e9c877affa0a51"
     }
     with create_test_context(params) as context:
-        lsp = LanguageServer.create(context.config, context.logger, context.source_directory)
+        lsp = SyncLanguageServer.create(context.config, context.logger, context.source_directory)
         test_file = str(PurePath("server/src/test/resources/definition/GoFrom.kt"))
         
-        async with lsp.start_server():
+        with lsp.start_server():
             with lsp.open_file(test_file):
-                definition_result = await lsp.request_definition(test_file, 2, 24)
+                definition_result = lsp.request_definition(test_file, 2, 24)
                 
                 assert definition_result is not None, "Definition result should not be None"
                 assert len(definition_result) == 1, "Should find exactly one definition"
@@ -73,20 +74,22 @@ async def test_definition() -> None:
                 assert definition["range"]["start"]["character"] == 8
                 assert definition["range"]["end"]["character"] == 24
 
-@pytest.mark.asyncio
-async def test_references() -> None:
+def test_sync_references() -> None:
+    """
+    Test references lookup functionality using the sync API
+    """
     params = {
         "code_language": Language.KOTLIN,
         "repo_url": "https://github.com/fwcd/kotlin-language-server/",
         "repo_commit": "8418fb560a4013c3e02c942797e9c877affa0a51"
     }
     with create_test_context(params) as context:
-        lsp = LanguageServer.create(context.config, context.logger, context.source_directory)
+        lsp = SyncLanguageServer.create(context.config, context.logger, context.source_directory)
         test_file = str(PurePath("server/src/test/resources/references/ReferenceTo.kt"))
         
-        async with lsp.start_server():
+        with lsp.start_server():
             with lsp.open_file(test_file):
-                references = await lsp.request_references(test_file, 1, 8)
+                references = lsp.request_references(test_file, 1, 8)
                 
                 assert references is not None, "References should not be None"
                 assert len(references) == 2, "Should find exactly two references to foo()"
@@ -105,20 +108,22 @@ async def test_references() -> None:
                 assert ref_to["range"]["start"]["line"] == 8
                 assert ref_to["range"]["start"]["character"] == 20
 
-@pytest.mark.asyncio
-async def test_hover() -> None:
+def test_sync_hover() -> None:
+    """
+    Test hover information functionality using the sync API
+    """
     params = {
         "code_language": Language.KOTLIN,
         "repo_url": "https://github.com/fwcd/kotlin-language-server/",
         "repo_commit": "8418fb560a4013c3e02c942797e9c877affa0a51"
     }
     with create_test_context(params) as context:
-        lsp = LanguageServer.create(context.config, context.logger, context.source_directory)
+        lsp = SyncLanguageServer.create(context.config, context.logger, context.source_directory)
         test_file = str(PurePath("server/src/test/resources/hover/Literals.kt"))
 
-        async with lsp.start_server():
+        with lsp.start_server():
             with lsp.open_file(test_file):
-                hover_result = await lsp.request_hover(test_file, 2, 19)
+                hover_result = lsp.request_hover(test_file, 2, 19)
 
                 assert hover_result is not None, "Hover result should not be None"
                 assert "contents" in hover_result, "Hover result should contain contents"
@@ -130,22 +135,24 @@ async def test_hover() -> None:
                 assert "```kotlin" in hover_result["contents"]["value"]
                 assert "val stringLiteral: String" in hover_result["contents"]["value"]
 
-@pytest.mark.asyncio
-async def test_completions() -> None:
+def test_sync_completions() -> None:
+    """
+    Test code completion functionality using the sync API
+    """
     params = {
         "code_language": Language.KOTLIN,
         "repo_url": "https://github.com/fwcd/kotlin-language-server/",
         "repo_commit": "8418fb560a4013c3e02c942797e9c877affa0a51"
     }
     with create_test_context(params) as context:
-        lsp = LanguageServer.create(context.config, context.logger, context.source_directory)
+        lsp = SyncLanguageServer.create(context.config, context.logger, context.source_directory)
         # Use a file specifically designed for testing completions
         test_file = str(PurePath("server/src/test/resources/completions/InstanceMember.kt"))
         
-        async with lsp.start_server():
+        with lsp.start_server():
             with lsp.open_file(test_file):
                 # Position after "instance." where completions should be available
-                completions = await lsp.request_completions(test_file, 2, 13)
+                completions = lsp.request_completions(test_file, 2, 13)
                 
                 assert completions is not None, "Completions result should not be None"
                 assert len(completions) > 0, "Should find at least one completion item"
@@ -163,4 +170,3 @@ async def test_completions() -> None:
                 found_expected = any(expected in completion_texts for expected in expected_completions)
                 
                 assert found_expected, f"Should find expected completions from {expected_completions}, but found: {completion_texts[:5]}"
-


### PR DESCRIPTION
Add Kotlin Language Server Support

Document symbols
Go to definition
Find references
Hover information
Code completions

Tested on Windows-x64 platforms with the kotlin-language-server from the fwcd/kotlin-language-server repository.