### PR TITLE
[Ruby] Fixed Solargraph install bug

### DIFF
--- a/src/multilspy/language_servers/solargraph/solargraph.py
+++ b/src/multilspy/language_servers/solargraph/solargraph.py
@@ -47,10 +47,6 @@ class Solargraph(LanguageServer):
         """
         Setup runtime dependencies for Solargraph.
         """
-        platform_id = PlatformUtils.get_platform_id()
-        which_cmd = "which"
-        if platform_id in [PlatformId.WIN_x64, PlatformId.WIN_arm64, PlatformId.WIN_x86]:
-            which_cmd = "where"
 
         with open(os.path.join(os.path.dirname(__file__), "runtime_dependencies.json"), "r") as f:
             d = json.load(f)

--- a/src/multilspy/language_servers/solargraph/solargraph.py
+++ b/src/multilspy/language_servers/solargraph/solargraph.py
@@ -74,23 +74,22 @@ class Solargraph(LanguageServer):
             if result.stdout.strip() == "false":
                 logger.log("Installing Solargraph...", logging.INFO)
                 subprocess.run(dependency["installCommand"].split(), check=True, capture_output=True, cwd=repository_root_path)
-        except subprocess.CalledProcessError as e:
-            raise RuntimeError(f"Failed to check or install Solargraph. {e.stderr}")
-
-        # Get the solargraph executable path
-        try:
-            result = subprocess.run([which_cmd, "solargraph"], check=True, capture_output=True, text=True, cwd=repository_root_path)
-            executeable_path = result.stdout.strip()
             
-            if not os.path.exists(executeable_path):
-                raise RuntimeError(f"Solargraph executable not found at {executeable_path}")
+            # Get the gem executable path directly
+            result = subprocess.run(["gem", "which", "solargraph"], check=True, capture_output=True, text=True, cwd=repository_root_path)
+            gem_path = result.stdout.strip()
+            bin_dir = os.path.join(os.path.dirname(os.path.dirname(gem_path)), "bin")
+            executable_path = os.path.join(bin_dir, "solargraph")
+            
+            if not os.path.exists(executable_path):
+                raise RuntimeError(f"Solargraph executable not found at {executable_path}")
             
             # Ensure the executable has the right permissions
-            os.chmod(executeable_path, os.stat(executeable_path).st_mode | stat.S_IEXEC)
+            os.chmod(executable_path, os.stat(executable_path).st_mode | stat.S_IEXEC)
 
-            return executeable_path
-        except subprocess.CalledProcessError:
-            raise RuntimeError("Failed to locate Solargraph executable.")
+            return executable_path
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"Failed to check or install Solargraph. {e.stderr}")
 
     def _get_initialize_params(self, repository_absolute_path: str) -> InitializeParams:
         """


### PR DESCRIPTION
Was having issues finding the solargraph executable directly in my $PATH (MacOS has a interesting relationship with Ruby).
 
So, I switched to using `gem which solargraph` instead which brings the behavior inline with how we install solargraph `gem install solargraph -v 0.51.1` and check if it's already present as a dependency `gem list solargraph`.