### PR TITLE
SyncLanguageServer.create - small documentation note

### DIFF
--- a/src/multilspy/language_server.py
+++ b/src/multilspy/language_server.py
@@ -679,7 +679,7 @@ class SyncLanguageServer:
 
         If language is Java, then ensure that jdk-17.0.6 or higher is installed, `java` is in PATH, and JAVA_HOME is set to the installation directory.
 
-        :param repository_root_path: The root path of the repository.
+        :param repository_root_path: The root path of the repository (must be absolute).
         :param config: The Multilspy configuration.
         :param logger: The logger to use.
 


### PR DESCRIPTION
To clarify that relative paths for repositories are not supported.

Currently if it's using relative path, `create_server` fails with traceback similar to the one below:
```python
Traceback (most recent call last):
  File "third_test.py", line 11, in <module>
    with lsp.start_server():
  File "\Python311\Lib\contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "\Python311\Lib\site-packages\multilspy\language_server.py", line 744, in start_server
    asyncio.run_coroutine_threadsafe(ctx.__aenter__(), loop=self.loop).result()
  File "\Python311\Lib\concurrent\futures\_base.py", line 456, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "\Python311\Lib\concurrent\futures\_base.py", line 401, in __get_result
    raise self._exception
  File "\Python311\Lib\contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "\Python311\Lib\site-packages\multilspy\language_servers\jedi_language_server\jedi_server.py", line 101, in start_server
    initialize_params = self._get_initialize_params(self.repository_root_path)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\Python311\Lib\site-packages\multilspy\language_servers\jedi_language_server\jedi_server.py", line 50, in _get_initialize_params
    d["rootUri"] = pathlib.Path(repository_absolute_path).as_uri()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\Python311\Lib\pathlib.py", line 566, in as_uri
    raise ValueError("relative path can't be expressed as a file URI")
ValueError: relative path can't be expressed as a file URI
```