### PR TITLE
Support for clojure via clojure-lsp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -397,14 +397,15 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 
-src/multilspy/language_servers/eclipse_jdtls/static/
-src/multilspy/language_servers/gopls/static/
-src/multilspy/language_servers/omnisharp/static/
-src/multilspy/language_servers/rust_analyzer/static/
-src/multilspy/language_servers/typescript_language_server/static/
-src/multilspy/language_servers/dart_language_server/static/
-src/multilspy/language_servers/clangd_language_server/static/
+# Downloaded language server binaries
+src/multilspy/language_servers/*/static/
 
 # Virtual Environment
 .venv/
 venv/
+
+# clojure-related temporary files
+.calva/
+.clj-kondo/
+.cpcache/
+.lsp/

--- a/src/multilspy/language_server.py
+++ b/src/multilspy/language_server.py
@@ -122,6 +122,10 @@ class LanguageServer:
             from multilspy.language_servers.clangd_language_server.clangd_language_server import ClangdLanguageServer
 
             return ClangdLanguageServer(config, logger, repository_root_path)
+        elif config.code_language == Language.CLOJURE:
+            from multilspy.language_servers.clojure_lsp.clojure_lsp import ClojureLSP
+
+            return ClojureLSP(config, logger, repository_root_path)
         else:
             logger.log(f"Language {config.code_language} is not supported", logging.ERROR)
             raise MultilspyException(f"Language {config.code_language} is not supported")

--- a/src/multilspy/language_server.py
+++ b/src/multilspy/language_server.py
@@ -384,7 +384,7 @@ class LanguageServer:
 
         if not self.server_started:
             self.logger.log(
-                "find_function_definition called before Language Server started",
+                "request_definition called before Language Server started",
                 logging.ERROR,
             )
             raise MultilspyException("Language Server not started")

--- a/src/multilspy/language_servers/clojure_lsp/clojure_lsp.py
+++ b/src/multilspy/language_servers/clojure_lsp/clojure_lsp.py
@@ -1,0 +1,174 @@
+"""
+Provides Clojure specific instantiation of the LanguageServer class. Contains various configurations and settings specific to Clojure.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import stat
+import pathlib
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+from multilspy.multilspy_logger import MultilspyLogger
+from multilspy.language_server import LanguageServer
+from multilspy.lsp_protocol_handler.server import ProcessLaunchInfo
+from multilspy.lsp_protocol_handler.lsp_types import InitializeParams
+from multilspy.multilspy_config import MultilspyConfig
+from multilspy.multilspy_utils import FileUtils
+from multilspy.multilspy_utils import PlatformUtils
+
+
+class ClojureLSP(LanguageServer):
+    """
+    Provides a clojure-lsp specific instantiation of the LanguageServer class. Contains various configurations and settings specific to clojure.
+    """
+
+    def __init__(self, config: MultilspyConfig, logger: MultilspyLogger, repository_root_path: str):
+        """
+        Creates a ClojureLSP instance. This class is not meant to be instantiated directly. Use LanguageServer.create() instead.
+        """
+        clojure_lsp_executable_path = self.setup_runtime_dependencies(logger, config)
+        super().__init__(
+            config,
+            logger,
+            repository_root_path,
+            ProcessLaunchInfo(cmd=clojure_lsp_executable_path, cwd=repository_root_path),
+            "clojure",
+        )
+        self.server_ready = asyncio.Event()
+        self.initialize_searcher_command_available = asyncio.Event()
+        self.resolve_main_method_available = asyncio.Event()
+        self.service_ready_event = asyncio.Event()
+    
+    def setup_runtime_dependencies(self, logger: MultilspyLogger, config: MultilspyConfig) -> str:
+        """
+        Setup runtime dependencies for clojure-lsp.
+        """
+        platform_id = PlatformUtils.get_platform_id()
+
+        with open(os.path.join(os.path.dirname(__file__), "runtime_dependencies.json"), "r", encoding="utf-8") as f:
+            d = json.load(f)
+            del d["_description"]
+
+        runtime_dependencies = d["runtimeDependencies"]
+        runtime_dependencies = [
+            dependency for dependency in runtime_dependencies if dependency["platformId"] == platform_id.value
+        ]
+        assert len(runtime_dependencies) == 1
+        dependency = runtime_dependencies[0]
+
+        clojurelsp_ls_dir = os.path.join(os.path.dirname(__file__), "static", "clojure-lsp")
+        clojurelsp_executable_path = os.path.join(clojurelsp_ls_dir, dependency["binaryName"])
+        if not os.path.exists(clojurelsp_ls_dir):
+            os.makedirs(clojurelsp_ls_dir)  
+            FileUtils.download_and_extract_archive(
+                logger, dependency["url"], clojurelsp_ls_dir, dependency["archiveType"]
+            )
+        assert os.path.exists(clojurelsp_executable_path)
+        os.chmod(clojurelsp_executable_path, stat.S_IEXEC)
+
+        return clojurelsp_executable_path
+
+    def _get_initialize_params(self, repository_absolute_path: str) -> InitializeParams:
+        """
+        Returns the init params for clojure-lsp.
+        """
+        with open(os.path.join(os.path.dirname(__file__), "initialize_params.json"), "r", encoding="utf-8") as f:
+            d = json.load(f)
+
+        del d["_description"]
+
+        d["processId"] = os.getpid()
+        assert d["rootPath"] == "$rootPath"
+        d["rootPath"] = repository_absolute_path
+
+        assert d["rootUri"] == "$rootUri"
+        d["rootUri"] = pathlib.Path(repository_absolute_path).as_uri()
+
+        assert d["workspaceFolders"][0]["uri"] == "$uri"
+        d["workspaceFolders"][0]["uri"] = pathlib.Path(repository_absolute_path).as_uri()
+
+        assert d["workspaceFolders"][0]["name"] == "$name"
+        d["workspaceFolders"][0]["name"] = os.path.basename(repository_absolute_path)
+
+        return d
+
+    @asynccontextmanager
+    async def start_server(self) -> AsyncIterator["ClojureLSP"]:
+        """
+        Starts the Clojure Language Server, waits for the server to be ready and yields the LanguageServer instance.
+
+        Usage:
+        ```
+        async with lsp.start_server():
+            # LanguageServer has been initialized and ready to serve requests
+            await lsp.request_definition(...)
+            await lsp.request_references(...)
+            # Shutdown the LanguageServer on exit from scope
+        # LanguageServer has been shutdown
+        """
+
+        async def register_capability_handler(params):
+            assert "registrations" in params
+            for registration in params["registrations"]:
+                if registration["method"] == "workspace/executeCommand":
+                    self.initialize_searcher_command_available.set()
+                    self.resolve_main_method_available.set()
+            return
+
+        async def lang_status_handler(params):
+            # TODO: Should we wait for
+            # server -> client: {'jsonrpc': '2.0', 'method': 'language/status', 'params': {'type': 'ProjectStatus', 'message': 'OK'}}
+            # Before proceeding?
+            if params["type"] == "ServiceReady" and params["message"] == "ServiceReady":
+                self.service_ready_event.set()
+
+        async def execute_client_command_handler(params):
+            return []
+
+        async def do_nothing(params):
+            return
+
+        async def check_experimental_status(params):
+            if params["quiescent"] == True:
+                self.server_ready.set()
+
+        async def window_log_message(msg):
+            self.logger.log(f"LSP: window/logMessage: {msg}", logging.INFO)
+
+        self.server.on_request("client/registerCapability", register_capability_handler)
+        self.server.on_notification("language/status", lang_status_handler)
+        self.server.on_notification("window/logMessage", window_log_message)
+        self.server.on_request("workspace/executeClientCommand", execute_client_command_handler)
+        self.server.on_notification("$/progress", do_nothing)
+        self.server.on_notification("textDocument/publishDiagnostics", do_nothing)
+        self.server.on_notification("language/actionableNotification", do_nothing)
+        self.server.on_notification("experimental/serverStatus", check_experimental_status)
+
+        async with super().start_server():
+            self.logger.log("Starting clojure-lsp server process", logging.INFO)
+            await self.server.start()
+            initialize_params = self._get_initialize_params(self.repository_root_path)
+
+            self.logger.log(
+                "Sending initialize request from LSP client to LSP server and awaiting response",
+                logging.INFO,
+            )
+            init_response = await self.server.send.initialize(initialize_params)
+            assert init_response["capabilities"]["textDocumentSync"]["change"] == 2
+            assert "completionProvider" in init_response["capabilities"]
+            # Clojure-lsp completion provider capabilities are more flexible than other servers
+            completion_provider = init_response["capabilities"]["completionProvider"]
+            assert completion_provider["resolveProvider"] == True
+            assert "triggerCharacters" in completion_provider
+            self.server.notify.initialized({})
+            # after initialize, Clojure-lsp is ready to serve
+            self.server_ready.set()
+            self.completions_available.set()
+
+            yield self
+
+            await self.server.shutdown()
+            await self.server.stop()

--- a/src/multilspy/language_servers/clojure_lsp/initialize_params.json
+++ b/src/multilspy/language_servers/clojure_lsp/initialize_params.json
@@ -1,0 +1,133 @@
+{
+    "_description": "Parameters sent by multilspy to initialize clojure-lsp (LSP v3.17)",
+    "processId": null,
+    "clientInfo": {
+        "name": "multilspy",
+        "version": "0.1.0"
+    },
+    "rootUri": "$rootUri",
+    "rootPath": "$rootPath",
+    "capabilities": {
+        "workspace": {
+            "applyEdit": true,
+            "workspaceEdit": {
+                "documentChanges": true
+            },
+            "symbol": {
+                "symbolKind": {
+                    "valueSet": [
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        8,
+                        9,
+                        10,
+                        11,
+                        12,
+                        13,
+                        14,
+                        15,
+                        16,
+                        17,
+                        18,
+                        19,
+                        20,
+                        21,
+                        22,
+                        23,
+                        24,
+                        25,
+                        26
+                    ]
+                }
+            },
+            "workspaceFolders": true
+        },
+        "textDocument": {
+            "synchronization": {
+                "didSave": true
+            },
+            "publishDiagnostics": {
+                "relatedInformation": true,
+                "tagSupport": {
+                    "valueSet": [
+                        1,
+                        2
+                    ]
+                }
+            },
+            "definition": {
+                "linkSupport": true
+            },
+            "references": {},
+            "completion": {
+                "completionItem": {
+                    "snippetSupport": true,
+                    "documentationFormat": [
+                        "markdown",
+                        "plaintext"
+                    ]
+                }
+            },
+            "hover": {
+                "contentFormat": [
+                    "markdown",
+                    "plaintext"
+                ]
+            },
+            "documentSymbol": {
+                "hierarchicalDocumentSymbolSupport": true,
+                "symbolKind": {
+                    "valueSet": [
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        8,
+                        9,
+                        10,
+                        11,
+                        12,
+                        13,
+                        14,
+                        15,
+                        16,
+                        17,
+                        18,
+                        19,
+                        20,
+                        21,
+                        22,
+                        23,
+                        24,
+                        25,
+                        26
+                    ]
+                }
+            }
+        },
+        "general": {
+            "positionEncodings": [
+                "utf-16"
+            ]
+        }
+    },
+    "initializationOptions": {
+        "dependency-scheme": "jar",
+        "text-document-sync-kind": "incremental"
+    },
+    "trace": "off",
+    "workspaceFolders": [
+        {
+            "uri": "$uri",
+            "name": "$name"
+        }
+    ]
+}

--- a/src/multilspy/language_servers/clojure_lsp/runtime_dependencies.json
+++ b/src/multilspy/language_servers/clojure_lsp/runtime_dependencies.json
@@ -1,0 +1,37 @@
+{
+    "_description": "Binary distributions of clojure-lsp.",
+    "runtimeDependencies": [
+        {
+            "id": "clojure-lsp",
+            "description": "clojure-lsp for OSX (ARM64)",
+            "url": "https://github.com/clojure-lsp/clojure-lsp/releases/latest/download/clojure-lsp-native-macos-aarch64.zip",
+            "platformId": "osx-arm64",
+            "archiveType": "zip",
+            "binaryName": "clojure-lsp"
+        },
+        {
+            "id": "clojure-lsp",
+            "description": "clojure-lsp for Linux (ARM64)",
+            "url": "https://github.com/clojure-lsp/clojure-lsp/releases/latest/download/clojure-lsp-native-linux-aarch64.zip",
+            "platformId": "linux-arm64",
+            "archiveType": "zip",
+            "binaryName": "clojure-lsp"
+        },
+        {
+            "id": "clojure-lsp",
+            "description": "clojure-lsp for Linux (x64)",
+            "url": "https://github.com/clojure-lsp/clojure-lsp/releases/latest/download/clojure-lsp-native-linux-amd64.zip",
+            "platformId": "linux-x64",
+            "archiveType": "zip",
+            "binaryName": "clojure-lsp"
+        },
+        {
+            "id": "clojure-lsp",
+            "description": "clojure-lsp for Windows (x64)",
+            "url": "https://github.com/clojure-lsp/clojure-lsp/releases/latest/download/clojure-lsp-native-windows-amd64.zip",
+            "platformId": "win-x64",
+            "archiveType": "zip",
+            "binaryName": "clojure-lsp"
+        }
+    ]
+}

--- a/src/multilspy/multilspy_config.py
+++ b/src/multilspy/multilspy_config.py
@@ -21,6 +21,7 @@ class Language(str, Enum):
     RUBY = "ruby"
     DART = "dart"
     CPP = "cpp"
+    CLOJURE = "clojure"
 
     def __str__(self) -> str:
         return self.value

--- a/tests/multilspy/clojure_test_repo/deps.edn
+++ b/tests/multilspy/clojure_test_repo/deps.edn
@@ -1,0 +1,5 @@
+{:paths ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.11.1"}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}}}}}

--- a/tests/multilspy/clojure_test_repo/src/test_app/core.clj
+++ b/tests/multilspy/clojure_test_repo/src/test_app/core.clj
@@ -1,0 +1,23 @@
+(ns test-app.core)
+
+(defn greet
+  "A simple greeting function"
+  [name]
+  (str "Hello, " name "!"))
+
+(defn add
+  "Adds two numbers"
+  [a b]
+  (+ a b))
+
+(defn multiply
+  "Multiplies two numbers"
+  [a b]
+  (* a b))
+
+(defn -main
+  "Main entry point"
+  [& args]
+  (println (greet "World"))
+  (println "2 + 3 =" (add 2 3))
+  (println "4 * 5 =" (multiply 4 5)))

--- a/tests/multilspy/clojure_test_repo/src/test_app/utils.clj
+++ b/tests/multilspy/clojure_test_repo/src/test_app/utils.clj
@@ -1,0 +1,17 @@
+(ns test-app.utils
+  (:require [test-app.core :as core]))
+
+(defn calculate-area
+  "Calculates the area of a rectangle"
+  [width height]
+  (core/multiply width height))
+
+(defn format-greeting
+  "Formats a greeting message"
+  [name]
+  (str "Welcome, " (core/greet name)))
+
+(defn sum-list
+  "Sums a list of numbers"
+  [numbers]
+  (reduce core/add 0 numbers))

--- a/tests/multilspy/test_multilspy_clojure.py
+++ b/tests/multilspy/test_multilspy_clojure.py
@@ -1,0 +1,189 @@
+"""
+Basic integration tests for the clojure-lsp language server.
+"""
+
+import pathlib
+
+import pytest
+import pytest_asyncio
+
+from multilspy.language_server import LanguageServer
+from multilspy.multilspy_config import Language, MultilspyConfig
+from multilspy.multilspy_logger import MultilspyLogger
+from multilspy.multilspy_types import Position
+
+pytest_plugins = ("pytest_asyncio",)
+
+
+@pytest_asyncio.fixture(scope="function")
+async def clojure_lsp():
+    """
+    FIXME: this should be a module-scoped fixture that creates and initializes a Clojure LSP server,
+      but pytest-asyncio's event loop does not support module-scoped fixtures.
+    """
+    config = MultilspyConfig(code_language=Language.CLOJURE)
+    logger = MultilspyLogger()
+    source_directory_path = str(pathlib.Path(__file__).parent / "clojure_test_repo")
+    lsp = LanguageServer.create(config, logger, source_directory_path)
+    
+    async with lsp.start_server():
+        yield lsp
+
+
+@pytest.mark.asyncio
+async def test_clojure_lsp_basic_definition(clojure_lsp):
+    """
+    Test the working of multilspy with Clojure - basic definition lookup
+    """
+    # Test finding definition of 'greet' function call in core.clj
+    filepath = "src/test_app/core.clj"
+    result = await clojure_lsp.request_definition(filepath, 20, 12)  # Position of 'greet' in (greet "World")
+
+    assert isinstance(result, list)
+    assert len(result) >= 1
+    
+    # Should find the definition of greet function
+    definition = result[0]
+    assert definition["relativePath"] == "src/test_app/core.clj"
+    assert definition["range"]["start"]["line"] == 2  # greet function definition line
+
+
+@pytest.mark.asyncio
+async def test_clojure_lsp_cross_file_references(clojure_lsp):
+    """
+    Test finding references across files in Clojure
+    """
+    # Test finding references to 'multiply' function from core.clj
+    filepath = "src/test_app/core.clj"
+    result = await clojure_lsp.request_references(filepath, 12, 6)  # Position of 'multiply' function definition
+
+    assert isinstance(result, list)
+    assert len(result) >= 2  # Should find definition + usage in utils.clj
+
+    # Should find usage in utils.clj calculate-area function
+    usage_found = any(
+        item["relativePath"] == "src/test_app/utils.clj" and 
+        item["range"]["start"]["line"] == 6  # multiply usage in calculate-area
+        for item in result
+    )
+    assert usage_found, "Should find multiply usage in utils.clj"
+
+
+@pytest.mark.asyncio
+async def test_clojure_lsp_completions(clojure_lsp):
+    """
+    Test code completions in Clojure
+    """
+    # Open a file and test completions
+    filepath = "src/test_app/utils.clj"
+    with clojure_lsp.open_file(filepath):
+        # Test completions for core/ namespace
+        result = await clojure_lsp.request_completions(filepath, 6, 8)  # After "core/" in calculate-area
+
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+        # Should find multiply and other core functions
+        completion_texts = [item["completionText"] for item in result]
+        assert any("multiply" in text for text in completion_texts)
+
+
+@pytest.mark.asyncio 
+async def test_clojure_lsp_document_symbols(clojure_lsp):
+    """
+    Test document symbols extraction in Clojure
+    """
+    filepath = "src/test_app/core.clj"
+    symbols, tree_repr = await clojure_lsp.request_document_symbols(filepath)
+
+    assert isinstance(symbols, list)
+    assert len(symbols) >= 4  # greet, add, multiply, -main functions
+
+    # Check that we find the expected function symbols
+    symbol_names = [symbol["name"] for symbol in symbols]
+    expected_functions = ["greet", "add", "multiply", "-main"]
+    
+    for func_name in expected_functions:
+        assert func_name in symbol_names, f"Should find {func_name} function in symbols"
+
+
+@pytest.mark.asyncio
+async def test_clojure_lsp_hover(clojure_lsp):
+    """
+    Test hover information in Clojure
+    """
+    # Test hover on greet function
+    filepath = "src/test_app/core.clj" 
+    result = await clojure_lsp.request_hover(filepath, 2, 7)  # Position on 'greet' function name
+
+    if result is not None:
+        assert "contents" in result
+        # Should contain function signature or documentation
+        contents = result["contents"]
+        if isinstance(contents, str):
+            assert "greet" in contents.lower()
+        elif isinstance(contents, dict) and "value" in contents:
+            assert "greet" in contents["value"].lower()
+
+
+@pytest.mark.asyncio
+async def test_clojure_lsp_workspace_symbols(clojure_lsp):
+    """
+    Test workspace symbol search in Clojure
+    """
+    # Search for functions containing "add"
+    result = await clojure_lsp.request_workspace_symbol("add")
+
+    if result is not None:
+        assert isinstance(result, list)
+        
+        # Should find the 'add' function
+        symbol_names = [symbol["name"] for symbol in result]
+        assert any("add" in name.lower() for name in symbol_names)
+
+
+@pytest.mark.asyncio
+async def test_clojure_lsp_file_operations(clojure_lsp):
+    """
+    Test file manipulation operations with Clojure LSP
+    """
+    filepath = "src/test_app/core.clj"
+    
+    with clojure_lsp.open_file(filepath):
+        original_text = clojure_lsp.get_open_file_text(filepath)
+        assert "greet" in original_text
+        
+        # Test inserting text
+        new_position = clojure_lsp.insert_text_at_position(filepath, 23, 0, "\n;; Test comment\n")
+        assert new_position["line"] == 25  # After insertion
+        
+        modified_text = clojure_lsp.get_open_file_text(filepath)
+        assert ";; Test comment" in modified_text
+        
+        # Test deleting text
+        start_pos = Position(line=23, character=0)
+        end_pos = Position(line=25, character=0)
+        deleted_text = clojure_lsp.delete_text_between_positions(filepath, start_pos, end_pos)
+        assert ";; Test comment" in deleted_text
+        
+        final_text = clojure_lsp.get_open_file_text(filepath)
+        assert final_text == original_text
+
+
+@pytest.mark.asyncio
+async def test_clojure_lsp_namespace_functions(clojure_lsp):
+    """
+    Test LSP functionality with namespaced functions
+    """
+    # Test definition lookup for core/greet usage in utils.clj
+    filepath = "src/test_app/utils.clj"
+    result = await clojure_lsp.request_definition(filepath, 11, 25)  # Position of 'greet' in core/greet call
+
+    assert isinstance(result, list)
+    assert len(result) >= 1
+    
+    # Should find the definition in core.clj
+    definition = result[0]
+    assert definition["relativePath"] == "src/test_app/core.clj"
+
+

--- a/tests/multilspy/test_sync_multilspy_clojure.py
+++ b/tests/multilspy/test_sync_multilspy_clojure.py
@@ -1,0 +1,174 @@
+"""
+Basic integration tests for the clojure-lsp language server (synchronous version).
+"""
+
+import pathlib
+import pytest
+
+from multilspy.language_server import SyncLanguageServer
+from multilspy.multilspy_config import Language, MultilspyConfig
+from multilspy.multilspy_logger import MultilspyLogger
+from multilspy.multilspy_types import Position
+
+
+@pytest.fixture(scope="session")
+def clojure_lsp():
+    """
+    Session-scoped fixture that creates and initializes a Clojure LSP server.
+    """
+    config = MultilspyConfig(code_language=Language.CLOJURE)
+    logger = MultilspyLogger()
+    source_directory_path = str(pathlib.Path(__file__).parent / "clojure_test_repo")
+    lsp = SyncLanguageServer.create(config, logger, source_directory_path)
+    
+    with lsp.start_server():
+        yield lsp
+
+
+def test_clojure_lsp_basic_definition(clojure_lsp):
+    """
+    Test the working of multilspy with Clojure - basic definition lookup
+    """
+    # Test finding definition of 'greet' function call in core.clj
+    filepath = "src/test_app/core.clj"
+    result = clojure_lsp.request_definition(filepath, 20, 12)  # Position of 'greet' in (greet "World")
+
+    assert isinstance(result, list)
+    assert len(result) >= 1
+    
+    # Should find the definition of greet function
+    definition = result[0]
+    assert definition["relativePath"] == "src/test_app/core.clj"
+    assert definition["range"]["start"]["line"] == 2  # greet function definition line
+
+
+def test_clojure_lsp_cross_file_references(clojure_lsp):
+    """
+    Test finding references across files in Clojure
+    """
+    # Test finding references to 'multiply' function from core.clj
+    filepath = "src/test_app/core.clj"
+    result = clojure_lsp.request_references(filepath, 12, 6)  # Position of 'multiply' function definition
+
+    assert isinstance(result, list)
+    assert len(result) >= 2  # Should find definition + usage in utils.clj
+
+    # Should find usage in utils.clj calculate-area function
+    usage_found = any(
+        item["relativePath"] == "src/test_app/utils.clj" and 
+        item["range"]["start"]["line"] == 6  # multiply usage in calculate-area
+        for item in result
+    )
+    assert usage_found, "Should find multiply usage in utils.clj"
+
+
+def test_clojure_lsp_completions(clojure_lsp):
+    """
+    Test code completions in Clojure
+    """
+    # Open a file and test completions
+    filepath = "src/test_app/utils.clj"
+    with clojure_lsp.open_file(filepath):
+        # Test completions for core/ namespace
+        result = clojure_lsp.request_completions(filepath, 6, 8)  # After "core/" in calculate-area
+
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+        # Should find multiply and other core functions
+        completion_texts = [item["completionText"] for item in result]
+        assert any("multiply" in text for text in completion_texts)
+
+
+def test_clojure_lsp_document_symbols(clojure_lsp):
+    """
+    Test document symbols extraction in Clojure
+    """
+    filepath = "src/test_app/core.clj"
+    symbols, tree_repr = clojure_lsp.request_document_symbols(filepath)
+
+    assert isinstance(symbols, list)
+    assert len(symbols) >= 4  # greet, add, multiply, -main functions
+
+    # Check that we find the expected function symbols
+    symbol_names = [symbol["name"] for symbol in symbols]
+    expected_functions = ["greet", "add", "multiply", "-main"]
+    
+    for func_name in expected_functions:
+        assert func_name in symbol_names, f"Should find {func_name} function in symbols"
+
+
+def test_clojure_lsp_hover(clojure_lsp):
+    """
+    Test hover information in Clojure
+    """
+    # Test hover on greet function
+    filepath = "src/test_app/core.clj" 
+    result = clojure_lsp.request_hover(filepath, 2, 7)  # Position on 'greet' function name
+
+    if result is not None:
+        assert "contents" in result
+        # Should contain function signature or documentation
+        contents = result["contents"]
+        if isinstance(contents, str):
+            assert "greet" in contents.lower()
+        elif isinstance(contents, dict) and "value" in contents:
+            assert "greet" in contents["value"].lower()
+
+
+def test_clojure_lsp_workspace_symbols(clojure_lsp):
+    """
+    Test workspace symbol search in Clojure
+    """
+    # Search for functions containing "add"
+    result = clojure_lsp.request_workspace_symbol("add")
+
+    if result is not None:
+        assert isinstance(result, list)
+        
+        # Should find the 'add' function
+        symbol_names = [symbol["name"] for symbol in result]
+        assert any("add" in name.lower() for name in symbol_names)
+
+
+def test_clojure_lsp_file_operations(clojure_lsp):
+    """
+    Test file manipulation operations with Clojure LSP
+    """
+    filepath = "src/test_app/core.clj"
+    
+    with clojure_lsp.open_file(filepath):
+        original_text = clojure_lsp.get_open_file_text(filepath)
+        assert "greet" in original_text
+        
+        # Test inserting text
+        new_position = clojure_lsp.insert_text_at_position(filepath, 23, 0, "\n;; Test comment\n")
+        assert new_position["line"] == 25  # After insertion
+        
+        modified_text = clojure_lsp.get_open_file_text(filepath)
+        assert ";; Test comment" in modified_text
+        
+        # Test deleting text
+        start_pos = Position(line=23, character=0)
+        end_pos = Position(line=25, character=0)
+        deleted_text = clojure_lsp.delete_text_between_positions(filepath, start_pos, end_pos)
+        assert ";; Test comment" in deleted_text
+        
+        final_text = clojure_lsp.get_open_file_text(filepath)
+        assert final_text == original_text
+
+
+def test_clojure_lsp_namespace_functions(clojure_lsp):
+    """
+    Test LSP functionality with namespaced functions
+    """
+    # Test definition lookup for core/greet usage in utils.clj
+    filepath = "src/test_app/utils.clj"
+    result = clojure_lsp.request_definition(filepath, 11, 25)  # Position of 'greet' in core/greet call
+
+    assert isinstance(result, list)
+    assert len(result) >= 1
+    
+    # Should find the definition in core.clj
+    definition = result[0]
+    assert definition["relativePath"] == "src/test_app/core.clj"


### PR DESCRIPTION
This PR adds support for [clojure-lsp](https://clojure-lsp.io/).

### Main changes

* Added a `ClojureLSP` class implementing `LanguageServer`.
* Added initialization parameters for the Clojure language server, including workspace and text document capabilities, as supported by multilspy
* Defined runtime dependencies for `clojure-lsp` across multiple platforms (e.g., OSX, Linux, Windows).
* Added `CLOJURE` as a new language option in the `Language` enum.

### Integration Tests

* Added tests for both sync and async server connections testing definition lookup, cross-file references, completions, document symbols, hover information, workspace symbols, file operations, and namespace function handling.
* Added a minimalistic sample clojure repo to avoid depending on an external source

### Other changes

* Updated `.gitignore`
* Fixed a small typo