### PR TITLE
fix: finalize even when exiting contextmanager by exception

### DIFF
--- a/src/multilspy/language_servers/clangd_language_server/clangd_language_server.py
+++ b/src/multilspy/language_servers/clangd_language_server/clangd_language_server.py
@@ -181,8 +181,8 @@ class ClangdLanguageServer(LanguageServer):
             # set ready flag
             self.server_ready.set()
             await self.server_ready.wait()
-
-            yield self
-
-            await self.server.shutdown()
-            await self.server.stop()
+            try:
+                yield self
+            finally:
+                await self.server.shutdown()
+                await self.server.stop()

--- a/src/multilspy/language_servers/dart_language_server/dart_language_server.py
+++ b/src/multilspy/language_servers/dart_language_server/dart_language_server.py
@@ -139,8 +139,8 @@ class DartLanguageServer(LanguageServer):
             )
 
             self.server.notify.initialized({})
-
-            yield self
-
-            await self.server.shutdown()
-            await self.server.stop()
+            try:
+                yield self
+            finally:
+                await self.server.shutdown()
+                await self.server.stop()

--- a/src/multilspy/language_servers/eclipse_jdtls/eclipse_jdtls.py
+++ b/src/multilspy/language_servers/eclipse_jdtls/eclipse_jdtls.py
@@ -398,8 +398,8 @@ class EclipseJDTLS(LanguageServer):
 
             # TODO: Add comments about why we wait here, and how this can be optimized
             await self.service_ready_event.wait()
-
-            yield self
-
-            await self.server.shutdown()
-            await self.server.stop()
+            try:
+                yield self
+            finally:
+                await self.server.shutdown()
+                await self.server.stop()

--- a/src/multilspy/language_servers/gopls/gopls.py
+++ b/src/multilspy/language_servers/gopls/gopls.py
@@ -144,8 +144,8 @@ class Gopls(LanguageServer):
             # gopls server is typically ready immediately after initialization
             self.server_ready.set()
             await self.server_ready.wait()
-
-            yield self
-
-            await self.server.shutdown()
-            await self.server.stop()
+            try:
+                yield self
+            finally:
+                await self.server.shutdown()
+                await self.server.stop()

--- a/src/multilspy/language_servers/jedi_language_server/jedi_server.py
+++ b/src/multilspy/language_servers/jedi_language_server/jedi_server.py
@@ -113,8 +113,8 @@ class JediServer(LanguageServer):
             }
 
             self.server.notify.initialized({})
-
-            yield self
-
-            await self.server.shutdown()
-            await self.server.stop()
+            try:
+                yield self
+            finally:
+                await self.server.shutdown()
+                await self.server.stop()

--- a/src/multilspy/language_servers/kotlin_language_server/kotlin_language_server.py
+++ b/src/multilspy/language_servers/kotlin_language_server/kotlin_language_server.py
@@ -223,12 +223,15 @@ class KotlinLanguageServer(LanguageServer):
             
             self.server.notify.initialized({})
             self.completions_available.set()
-
-            yield self
-
             try:
-                await self.server.shutdown()
-            except Exception as e:
-                self.logger.log(f"Error during Kotlin server shutdown: {str(e)}", logging.WARNING)
+                yield self
             finally:
-                await self.server.stop()
+                try:
+                    await self.server.shutdown()
+                except Exception as e:
+                    self.logger.log(
+                        f"Error during Kotlin server shutdown: {str(e)}",
+                        logging.WARNING,
+                    )
+                finally:
+                    await self.server.stop()

--- a/src/multilspy/language_servers/omnisharp/omnisharp.py
+++ b/src/multilspy/language_servers/omnisharp/omnisharp.py
@@ -396,8 +396,8 @@ class OmniSharp(LanguageServer):
 
             await self.definition_available.wait()
             await self.references_available.wait()
-
-            yield self
-
-            await self.server.shutdown()
-            await self.server.stop()
+            try:
+                yield self
+            finally:
+                await self.server.shutdown()
+                await self.server.stop()

--- a/src/multilspy/language_servers/rust_analyzer/rust_analyzer.py
+++ b/src/multilspy/language_servers/rust_analyzer/rust_analyzer.py
@@ -175,8 +175,8 @@ class RustAnalyzer(LanguageServer):
             self.completions_available.set()
 
             await self.server_ready.wait()
-
-            yield self
-
-            await self.server.shutdown()
-            await self.server.stop()
+            try:
+                yield self
+            finally:
+                await self.server.shutdown()
+                await self.server.stop()

--- a/src/multilspy/language_servers/solargraph/solargraph.py
+++ b/src/multilspy/language_servers/solargraph/solargraph.py
@@ -181,8 +181,8 @@ class Solargraph(LanguageServer):
 
             self.server_ready.set()
             await self.server_ready.wait()
-
-            yield self
-
-            await self.server.shutdown()
-            await self.server.stop()
+            try:
+                yield self
+            finally:
+                await self.server.shutdown()
+                await self.server.stop()

--- a/src/multilspy/language_servers/typescript_language_server/typescript_language_server.py
+++ b/src/multilspy/language_servers/typescript_language_server/typescript_language_server.py
@@ -195,8 +195,8 @@ class TypeScriptLanguageServer(LanguageServer):
             # TypeScript server is typically ready immediately after initialization
             self.server_ready.set()
             await self.server_ready.wait()
-
-            yield self
-
-            await self.server.shutdown()
-            await self.server.stop()
+            try:
+                yield self
+            finally:
+                await self.server.shutdown()
+                await self.server.stop()


### PR DESCRIPTION
Contextmanager does not process the finalize process in try-finally and may not execute when exiting contextmanager with an error.
Unintended results were observed due to the different state of the file from the application using LSP.

```py
from contextlib import contextmanager


@contextmanager
def sample():
    try:
        yield
        print("a")
    finally:
        print("b")

with sample():
    raise Exception # Show only b
```