### PR TITLE
Fix platformId for clangd on Windows

### DIFF
--- a/src/multilspy/language_servers/clangd_language_server/runtime_dependencies.json
+++ b/src/multilspy/language_servers/clangd_language_server/runtime_dependencies.json
@@ -13,7 +13,7 @@
             "id": "Clangd",
             "description": "Clangd for Windows (x64)",
             "url": "https://github.com/clangd/clangd/releases/download/19.1.2/clangd-windows-19.1.2.zip",
-            "platformId": "windows-x64",
+            "platformId": "win-x64",
             "archiveType": "zip",
             "binaryName": "clangd.exe"
         },


### PR DESCRIPTION
The `platformId` of `windows-x64` does not exist, it is `win-x64`.