### PR TITLE
Allow customizing the LSP binary

### DIFF
--- a/src/multilspy/language_servers/rust_analyzer/rust_analyzer.py
+++ b/src/multilspy/language_servers/rust_analyzer/rust_analyzer.py
@@ -43,6 +43,12 @@ class RustAnalyzer(LanguageServer):
         """
         Setup runtime dependencies for rust_analyzer.
         """
+        
+        if config.custom_lsp_binary:
+            path = os.path.abspath(config.custom_lsp_binary)
+            assert os.path.exists(path)
+            return path
+
         platform_id = PlatformUtils.get_platform_id()
 
         with open(os.path.join(os.path.dirname(__file__), "runtime_dependencies.json"), "r") as f:

--- a/src/multilspy/multilspy_config.py
+++ b/src/multilspy/multilspy_config.py
@@ -4,6 +4,7 @@ Configuration parameters for Multilspy.
 
 from enum import Enum
 from dataclasses import dataclass
+from typing import Optional
 
 class Language(str, Enum):
     """
@@ -33,6 +34,8 @@ class MultilspyConfig:
     code_language: Language
     trace_lsp_communication: bool = False
     start_independent_lsp_process: bool = True
+    # Only works for Rust Analyzer
+    custom_lsp_binary: Optional[bool] = None
 
     @classmethod
     def from_dict(cls, env: dict):


### PR DESCRIPTION
Sometimes the provided LSP binary isn't up-to-date enough for particular projects. This small change makes it possible to customize the binary used via the `MultilspyConfig`.

I've only done this for rust-analyzer, but if this is something you'd want to include in main, then I can add a commit for the other LSPs.