### PR TITLE
Fix interrupted download recovery: check executable, not directory

### DIFF
--- a/src/multilspy/language_servers/clangd_language_server/clangd_language_server.py
+++ b/src/multilspy/language_servers/clangd_language_server/clangd_language_server.py
@@ -69,8 +69,8 @@ class ClangdLanguageServer(LanguageServer):
 
         clangd_ls_dir = os.path.join(os.path.dirname(__file__), "static", "clangd")
         clangd_executable_path = os.path.join(clangd_ls_dir, "clangd_19.1.2", "bin", dependency["binaryName"])
-        if not os.path.exists(clangd_ls_dir):
-            os.makedirs(clangd_ls_dir)
+        if not os.path.exists(clangd_executable_path):
+            os.makedirs(clangd_ls_dir, exist_ok=True)
             if dependency["archiveType"] == "zip":
                 FileUtils.download_and_extract_archive(
                     logger, dependency["url"], clangd_ls_dir, dependency["archiveType"]

--- a/src/multilspy/language_servers/dart_language_server/dart_language_server.py
+++ b/src/multilspy/language_servers/dart_language_server/dart_language_server.py
@@ -48,8 +48,8 @@ class DartLanguageServer(LanguageServer):
         dart_ls_dir = os.path.join(os.path.dirname(__file__), "static", "dart-language-server")
         dart_executable_path = os.path.join(dart_ls_dir, dependency["binaryName"])
 
-        if not os.path.exists(dart_ls_dir):
-            os.makedirs(dart_ls_dir)
+        if not os.path.exists(dart_executable_path):
+            os.makedirs(dart_ls_dir, exist_ok=True)
             FileUtils.download_and_extract_archive(
                 logger, dependency["url"], dart_ls_dir, dependency["archiveType"]
             )

--- a/src/multilspy/language_servers/omnisharp/omnisharp.py
+++ b/src/multilspy/language_servers/omnisharp/omnisharp.py
@@ -178,24 +178,24 @@ class OmniSharp(LanguageServer):
         assert "RazorOmnisharp" in runtime_dependencies
 
         omnisharp_ls_dir = os.path.join(os.path.dirname(__file__), "static", "OmniSharp")
-        if not os.path.exists(omnisharp_ls_dir):
-            os.makedirs(omnisharp_ls_dir)
+        omnisharp_executable_path = os.path.join(omnisharp_ls_dir, runtime_dependencies["OmniSharp"]["binaryName"])
+        if not os.path.exists(omnisharp_executable_path):
+            os.makedirs(omnisharp_ls_dir, exist_ok=True)
             FileUtils.download_and_extract_archive(
                 logger, runtime_dependencies["OmniSharp"]["url"], omnisharp_ls_dir, "zip"
             )
-        omnisharp_executable_path = os.path.join(omnisharp_ls_dir, runtime_dependencies["OmniSharp"]["binaryName"])
         assert os.path.exists(omnisharp_executable_path)
         os.chmod(omnisharp_executable_path, stat.S_IEXEC)
 
         razor_omnisharp_ls_dir = os.path.join(os.path.dirname(__file__), "static", "RazorOmnisharp")
-        if not os.path.exists(razor_omnisharp_ls_dir):
-            os.makedirs(razor_omnisharp_ls_dir)
-            FileUtils.download_and_extract_archive(
-                logger, runtime_dependencies["RazorOmnisharp"]["url"], razor_omnisharp_ls_dir, "zip"
-            )
         razor_omnisharp_dll_path = os.path.join(
             razor_omnisharp_ls_dir, runtime_dependencies["RazorOmnisharp"]["dll_path"]
         )
+        if not os.path.exists(razor_omnisharp_dll_path):
+            os.makedirs(razor_omnisharp_ls_dir, exist_ok=True)
+            FileUtils.download_and_extract_archive(
+                logger, runtime_dependencies["RazorOmnisharp"]["url"], razor_omnisharp_ls_dir, "zip"
+            )
         assert os.path.exists(razor_omnisharp_dll_path)
 
         return omnisharp_executable_path, razor_omnisharp_dll_path

--- a/src/multilspy/language_servers/rust_analyzer/rust_analyzer.py
+++ b/src/multilspy/language_servers/rust_analyzer/rust_analyzer.py
@@ -63,8 +63,8 @@ class RustAnalyzer(LanguageServer):
 
         rustanalyzer_ls_dir = os.path.join(os.path.dirname(__file__), "static", "RustAnalyzer")
         rustanalyzer_executable_path = os.path.join(rustanalyzer_ls_dir, dependency["binaryName"])
-        if not os.path.exists(rustanalyzer_ls_dir):
-            os.makedirs(rustanalyzer_ls_dir)
+        if not os.path.exists(rustanalyzer_executable_path):
+            os.makedirs(rustanalyzer_ls_dir, exist_ok=True)
             if dependency["archiveType"] == "gz":
                 FileUtils.download_and_extract_archive(
                     logger, dependency["url"], rustanalyzer_executable_path, dependency["archiveType"]

--- a/src/multilspy/language_servers/typescript_language_server/typescript_language_server.py
+++ b/src/multilspy/language_servers/typescript_language_server/typescript_language_server.py
@@ -76,7 +76,8 @@ class TypeScriptLanguageServer(LanguageServer):
         assert is_npm_installed, "npm is not installed or isn't in PATH. Please install npm and try again."
 
         # Install typescript and typescript-language-server if not already installed
-        if not os.path.exists(tsserver_ls_dir):
+        tsserver_executable_path = os.path.join(tsserver_ls_dir, "node_modules", ".bin", "typescript-language-server")
+        if not os.path.exists(tsserver_executable_path):
             os.makedirs(tsserver_ls_dir, exist_ok=True)
             for dependency in runtime_dependencies:
                 # Windows doesn't support the 'user' parameter and doesn't have pwd module
@@ -102,7 +103,6 @@ class TypeScriptLanguageServer(LanguageServer):
                         stderr=subprocess.DEVNULL
                     )
         
-        tsserver_executable_path = os.path.join(tsserver_ls_dir, "node_modules", ".bin", "typescript-language-server")
         assert os.path.exists(tsserver_executable_path), "typescript-language-server executable not found. Please install typescript-language-server and try again."
         return f"{tsserver_executable_path} --stdio"
 


### PR DESCRIPTION
## Summary

If a language server binary download is interrupted (crash, kill, network timeout), the target directory exists but the executable does not. On next invocation, the directory-existence check passes, the download is skipped, and an `AssertionError` is raised because the executable is missing.

Fix: check for the **executable** instead of the **directory**, and use `exist_ok=True` on `makedirs` so a leftover directory from a previous attempt doesn't cause errors.

Affected servers:
- **rust-analyzer** — `rustanalyzer_ls_dir` → `rustanalyzer_executable_path`
- **dart** — `dart_ls_dir` → `dart_executable_path`
- **clangd** — `clangd_ls_dir` → `clangd_executable_path`
- **omnisharp** — `omnisharp_ls_dir` → `omnisharp_executable_path`, `razor_omnisharp_ls_dir` → `razor_omnisharp_dll_path`
- **typescript** — `tsserver_ls_dir` → `tsserver_executable_path`

Not affected (already correct): kotlin, solargraph, jedi.

Fixes #131