### PR TITLE
Move LSP installs to ~/.multilspy/lsp/, add server_binary and server_install_dir config

### DIFF
--- a/src/multilspy/language_servers/clangd_language_server/clangd_language_server.py
+++ b/src/multilspy/language_servers/clangd_language_server/clangd_language_server.py
@@ -18,6 +18,7 @@ from multilspy.lsp_protocol_handler.lsp_types import InitializeParams
 from multilspy.multilspy_config import MultilspyConfig
 from multilspy.multilspy_utils import FileUtils
 from multilspy.multilspy_utils import PlatformUtils
+from multilspy.multilspy_settings import MultilspySettings
 
 
 class ClangdLanguageServer(LanguageServer):
@@ -45,6 +46,10 @@ class ClangdLanguageServer(LanguageServer):
         """
         Setup runtime dependencies for ClangdLanguageServer.
         """
+        if config.server_binary:
+            assert os.path.exists(config.server_binary), f"Server binary not found: {config.server_binary}"
+            return config.server_binary
+
         platform_id = PlatformUtils.get_platform_id()
 
         with open(os.path.join(os.path.dirname(__file__), "runtime_dependencies.json"), "r") as f:
@@ -67,7 +72,7 @@ class ClangdLanguageServer(LanguageServer):
         if dependency is None:
             raise RuntimeError(f"No runtime dependency found for platform {platform_id.value}")
 
-        clangd_ls_dir = os.path.join(os.path.dirname(__file__), "static", "clangd")
+        clangd_ls_dir = config.server_install_dir or MultilspySettings.get_server_install_directory("clangd")
         clangd_executable_path = os.path.join(clangd_ls_dir, "clangd_19.1.2", "bin", dependency["binaryName"])
         if not os.path.exists(clangd_executable_path):
             os.makedirs(clangd_ls_dir, exist_ok=True)

--- a/src/multilspy/language_servers/dart_language_server/dart_language_server.py
+++ b/src/multilspy/language_servers/dart_language_server/dart_language_server.py
@@ -8,6 +8,8 @@ from typing import AsyncIterator
 from multilspy.language_server import LanguageServer
 from multilspy.lsp_protocol_handler.server import ProcessLaunchInfo
 import json
+from multilspy.multilspy_config import MultilspyConfig
+from multilspy.multilspy_settings import MultilspySettings
 from multilspy.multilspy_utils import FileUtils, PlatformUtils
 
 
@@ -21,7 +23,7 @@ class DartLanguageServer(LanguageServer):
         Creates a DartServer instance. This class is not meant to be instantiated directly. Use LanguageServer.create() instead.
         """
 
-        executable_path = self.setup_runtime_dependencies(logger)
+        executable_path = self.setup_runtime_dependencies(logger, config)
         super().__init__(
             config,
             logger,
@@ -30,7 +32,11 @@ class DartLanguageServer(LanguageServer):
             "dart",
         )
 
-    def setup_runtime_dependencies(self, logger: "MultilspyLogger") -> str:
+    def setup_runtime_dependencies(self, logger: "MultilspyLogger", config: MultilspyConfig) -> str:
+        if config.server_binary:
+            assert os.path.exists(config.server_binary), f"Server binary not found: {config.server_binary}"
+            return f"{config.server_binary} language-server --client-id multilspy.dart --client-version 1.2"
+
         platform_id = PlatformUtils.get_platform_id()
 
         with open(os.path.join(os.path.dirname(__file__), "runtime_dependencies.json"), "r") as f:
@@ -45,7 +51,7 @@ class DartLanguageServer(LanguageServer):
         assert len(runtime_dependencies) == 1
         dependency = runtime_dependencies[0]
 
-        dart_ls_dir = os.path.join(os.path.dirname(__file__), "static", "dart-language-server")
+        dart_ls_dir = config.server_install_dir or MultilspySettings.get_server_install_directory("dart-language-server")
         dart_executable_path = os.path.join(dart_ls_dir, dependency["binaryName"])
 
         if not os.path.exists(dart_executable_path):

--- a/src/multilspy/language_servers/eclipse_jdtls/eclipse_jdtls.py
+++ b/src/multilspy/language_servers/eclipse_jdtls/eclipse_jdtls.py
@@ -149,17 +149,13 @@ class EclipseJDTLS(LanguageServer):
             runtimeDependencies = json.load(f)
             del runtimeDependencies["_description"]
 
-        os.makedirs(str(PurePath(os.path.abspath(os.path.dirname(__file__)), "static")), exist_ok=True)
-
-        # assert platformId.value in [
-        #     "linux-x64",
-        #     "win-x64",
-        # ], "Only linux-x64 platform is supported for in multilspy at the moment"
+        static_dir = config.server_install_dir or MultilspySettings.get_server_install_directory("EclipseJDTLS")
+        os.makedirs(static_dir, exist_ok=True)
 
         gradle_path = str(
             PurePath(
-                os.path.abspath(os.path.dirname(__file__)),
-                "static/gradle-7.3.3",
+                static_dir,
+                "gradle-7.3.3",
             )
         )
 
@@ -175,7 +171,7 @@ class EclipseJDTLS(LanguageServer):
 
         dependency = runtimeDependencies["vscode-java"][platformId.value]
         vscode_java_path = str(
-            PurePath(os.path.abspath(os.path.dirname(__file__)), "static", dependency["relative_extraction_path"])
+            PurePath(static_dir, dependency["relative_extraction_path"])
         )
         os.makedirs(vscode_java_path, exist_ok=True)
         jre_home_path = str(PurePath(vscode_java_path, dependency["jre_home_path"]))
@@ -208,7 +204,7 @@ class EclipseJDTLS(LanguageServer):
 
         dependency = runtimeDependencies["intellicode"]["platform-agnostic"]
         intellicode_directory_path = str(
-            PurePath(os.path.abspath(os.path.dirname(__file__)), "static", dependency["relative_extraction_path"])
+            PurePath(static_dir, dependency["relative_extraction_path"])
         )
         os.makedirs(intellicode_directory_path, exist_ok=True)
         intellicode_jar_path = str(PurePath(intellicode_directory_path, dependency["intellicode_jar_path"]))

--- a/src/multilspy/language_servers/gopls/gopls.py
+++ b/src/multilspy/language_servers/gopls/gopls.py
@@ -68,14 +68,19 @@ class Gopls(LanguageServer):
         return True
 
     def __init__(self, config: MultilspyConfig, logger: MultilspyLogger, repository_root_path: str):
-        # Check runtime dependencies before initializing
-        self.setup_runtime_dependency()
-        
+        if config.server_binary:
+            assert os.path.exists(config.server_binary), f"Server binary not found: {config.server_binary}"
+            cmd = config.server_binary
+        else:
+            # Check runtime dependencies before initializing
+            self.setup_runtime_dependency()
+            cmd = "gopls"
+
         super().__init__(
             config,
             logger,
             repository_root_path,
-            ProcessLaunchInfo(cmd="gopls", cwd=repository_root_path),
+            ProcessLaunchInfo(cmd=cmd, cwd=repository_root_path),
             "go",
         )
         self.server_ready = asyncio.Event()

--- a/src/multilspy/language_servers/jedi_language_server/jedi_server.py
+++ b/src/multilspy/language_servers/jedi_language_server/jedi_server.py
@@ -29,7 +29,7 @@ class JediServer(LanguageServer):
             config,
             logger,
             repository_root_path,
-            ProcessLaunchInfo(cmd="jedi-language-server", cwd=repository_root_path),
+            ProcessLaunchInfo(cmd=config.server_binary or "jedi-language-server", cwd=repository_root_path),
             "python",
         )
 

--- a/src/multilspy/language_servers/kotlin_language_server/kotlin_language_server.py
+++ b/src/multilspy/language_servers/kotlin_language_server/kotlin_language_server.py
@@ -19,6 +19,7 @@ from multilspy.lsp_protocol_handler.lsp_types import InitializeParams
 from multilspy.multilspy_config import MultilspyConfig
 from multilspy.multilspy_utils import FileUtils
 from multilspy.multilspy_utils import PlatformUtils
+from multilspy.multilspy_settings import MultilspySettings
 
 
 @dataclasses.dataclass
@@ -75,7 +76,7 @@ class KotlinLanguageServer(LanguageServer):
         java_dependency = d["java"][platform_id.value]
 
         # Setup paths for dependencies
-        static_dir = os.path.join(os.path.dirname(__file__), "static")
+        static_dir = config.server_install_dir or MultilspySettings.get_server_install_directory("KotlinLanguageServer")
         os.makedirs(static_dir, exist_ok=True)
         
         # Setup Java paths

--- a/src/multilspy/language_servers/omnisharp/omnisharp.py
+++ b/src/multilspy/language_servers/omnisharp/omnisharp.py
@@ -19,6 +19,7 @@ from multilspy.lsp_protocol_handler.lsp_types import InitializeParams
 from multilspy.multilspy_config import MultilspyConfig
 from multilspy.multilspy_exceptions import MultilspyException
 from multilspy.multilspy_utils import FileUtils, PlatformUtils, PlatformId, DotnetVersion
+from multilspy.multilspy_settings import MultilspySettings
 
 
 def breadth_first_file_scan(root) -> Iterable[str]:
@@ -137,6 +138,10 @@ class OmniSharp(LanguageServer):
         """
         Setup runtime dependencies for OmniSharp.
         """
+        if config.server_binary:
+            assert os.path.exists(config.server_binary), f"Server binary not found: {config.server_binary}"
+            return config.server_binary, ""
+
         platform_id = PlatformUtils.get_platform_id()
         dotnet_version = PlatformUtils.get_dotnet_version()
 
@@ -177,7 +182,8 @@ class OmniSharp(LanguageServer):
         assert "OmniSharp" in runtime_dependencies
         assert "RazorOmnisharp" in runtime_dependencies
 
-        omnisharp_ls_dir = os.path.join(os.path.dirname(__file__), "static", "OmniSharp")
+        base_install_dir = config.server_install_dir or MultilspySettings.get_server_install_directory("OmniSharp")
+        omnisharp_ls_dir = os.path.join(base_install_dir, "OmniSharp")
         omnisharp_executable_path = os.path.join(omnisharp_ls_dir, runtime_dependencies["OmniSharp"]["binaryName"])
         if not os.path.exists(omnisharp_executable_path):
             os.makedirs(omnisharp_ls_dir, exist_ok=True)
@@ -187,7 +193,7 @@ class OmniSharp(LanguageServer):
         assert os.path.exists(omnisharp_executable_path)
         os.chmod(omnisharp_executable_path, stat.S_IEXEC)
 
-        razor_omnisharp_ls_dir = os.path.join(os.path.dirname(__file__), "static", "RazorOmnisharp")
+        razor_omnisharp_ls_dir = os.path.join(base_install_dir, "RazorOmnisharp")
         razor_omnisharp_dll_path = os.path.join(
             razor_omnisharp_ls_dir, runtime_dependencies["RazorOmnisharp"]["dll_path"]
         )

--- a/src/multilspy/language_servers/rust_analyzer/rust_analyzer.py
+++ b/src/multilspy/language_servers/rust_analyzer/rust_analyzer.py
@@ -18,6 +18,7 @@ from multilspy.lsp_protocol_handler.lsp_types import InitializeParams
 from multilspy.multilspy_config import MultilspyConfig
 from multilspy.multilspy_utils import FileUtils
 from multilspy.multilspy_utils import PlatformUtils
+from multilspy.multilspy_settings import MultilspySettings
 
 
 class RustAnalyzer(LanguageServer):
@@ -43,16 +44,15 @@ class RustAnalyzer(LanguageServer):
         """
         Setup runtime dependencies for rust_analyzer.
         """
+        if config.server_binary:
+            assert os.path.exists(config.server_binary), f"Server binary not found: {config.server_binary}"
+            return config.server_binary
+
         platform_id = PlatformUtils.get_platform_id()
 
         with open(os.path.join(os.path.dirname(__file__), "runtime_dependencies.json"), "r") as f:
             d = json.load(f)
             del d["_description"]
-
-        # assert platform_id.value in [
-        #     "linux-x64",
-        #     "win-x64",
-        # ], "Only linux-x64 and win-x64 platform is supported for in multilspy at the moment"
 
         runtime_dependencies = d["runtimeDependencies"]
         runtime_dependencies = [
@@ -61,7 +61,7 @@ class RustAnalyzer(LanguageServer):
         assert len(runtime_dependencies) == 1
         dependency = runtime_dependencies[0]
 
-        rustanalyzer_ls_dir = os.path.join(os.path.dirname(__file__), "static", "RustAnalyzer")
+        rustanalyzer_ls_dir = config.server_install_dir or MultilspySettings.get_server_install_directory("RustAnalyzer")
         rustanalyzer_executable_path = os.path.join(rustanalyzer_ls_dir, dependency["binaryName"])
         if not os.path.exists(rustanalyzer_executable_path):
             os.makedirs(rustanalyzer_ls_dir, exist_ok=True)

--- a/src/multilspy/language_servers/solargraph/solargraph.py
+++ b/src/multilspy/language_servers/solargraph/solargraph.py
@@ -47,6 +47,9 @@ class Solargraph(LanguageServer):
         """
         Setup runtime dependencies for Solargraph.
         """
+        if config.server_binary:
+            assert os.path.exists(config.server_binary), f"Server binary not found: {config.server_binary}"
+            return config.server_binary
 
         with open(os.path.join(os.path.dirname(__file__), "runtime_dependencies.json"), "r") as f:
             d = json.load(f)

--- a/src/multilspy/language_servers/typescript_language_server/typescript_language_server.py
+++ b/src/multilspy/language_servers/typescript_language_server/typescript_language_server.py
@@ -18,6 +18,7 @@ from multilspy.lsp_protocol_handler.server import ProcessLaunchInfo
 from multilspy.lsp_protocol_handler.lsp_types import InitializeParams
 from multilspy.multilspy_config import MultilspyConfig
 from multilspy.multilspy_utils import PlatformUtils, PlatformId
+from multilspy.multilspy_settings import MultilspySettings
 
 
 # Conditionally import pwd module (Unix-only)
@@ -48,17 +49,21 @@ class TypeScriptLanguageServer(LanguageServer):
         """
         Setup runtime dependencies for TypeScript Language Server.
         """
+        if config.server_binary:
+            assert os.path.exists(config.server_binary), f"Server binary not found: {config.server_binary}"
+            return f"{config.server_binary} --stdio"
+
         platform_id = PlatformUtils.get_platform_id()
 
         valid_platforms = [
-            PlatformId.LINUX_x64, 
+            PlatformId.LINUX_x64,
             PlatformId.LINUX_arm64,
-            PlatformId.OSX, 
+            PlatformId.OSX,
             PlatformId.OSX_x64,
             PlatformId.OSX_arm64,
-            PlatformId.WIN_x64, 
-            PlatformId.WIN_arm64, 
-        ] 
+            PlatformId.WIN_x64,
+            PlatformId.WIN_arm64,
+        ]
         assert platform_id in valid_platforms, f"Platform {platform_id} is not supported for multilspy javascript/typescript at the moment"
 
         with open(os.path.join(os.path.dirname(__file__), "runtime_dependencies.json"), "r") as f:
@@ -66,8 +71,8 @@ class TypeScriptLanguageServer(LanguageServer):
             del d["_description"]
 
         runtime_dependencies = d.get("runtimeDependencies", [])
-        tsserver_ls_dir = os.path.join(os.path.dirname(__file__), "static", "ts-lsp")
-        tsserver_executable_path = os.path.join(tsserver_ls_dir, "typescript-language-server")
+        tsserver_ls_dir = config.server_install_dir or MultilspySettings.get_server_install_directory("ts-lsp")
+        tsserver_executable_path = os.path.join(tsserver_ls_dir, "node_modules", ".bin", "typescript-language-server")
 
         # Verify both node and npm are installed
         is_node_installed = shutil.which('node') is not None
@@ -76,16 +81,15 @@ class TypeScriptLanguageServer(LanguageServer):
         assert is_npm_installed, "npm is not installed or isn't in PATH. Please install npm and try again."
 
         # Install typescript and typescript-language-server if not already installed
-        tsserver_executable_path = os.path.join(tsserver_ls_dir, "node_modules", ".bin", "typescript-language-server")
         if not os.path.exists(tsserver_executable_path):
             os.makedirs(tsserver_ls_dir, exist_ok=True)
             for dependency in runtime_dependencies:
                 # Windows doesn't support the 'user' parameter and doesn't have pwd module
                 if PlatformUtils.get_platform_id().value.startswith("win"):
                     subprocess.run(
-                        dependency["command"], 
-                        shell=True, 
-                        check=True, 
+                        dependency["command"],
+                        shell=True,
+                        check=True,
                         cwd=tsserver_ls_dir,
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL
@@ -94,15 +98,15 @@ class TypeScriptLanguageServer(LanguageServer):
                     # On Unix-like systems, run as non-root user
                     user = pwd.getpwuid(os.getuid()).pw_name
                     subprocess.run(
-                        dependency["command"], 
-                        shell=True, 
-                        check=True, 
-                        user=user, 
+                        dependency["command"],
+                        shell=True,
+                        check=True,
+                        user=user,
                         cwd=tsserver_ls_dir,
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL
                     )
-        
+
         assert os.path.exists(tsserver_executable_path), "typescript-language-server executable not found. Please install typescript-language-server and try again."
         return f"{tsserver_executable_path} --stdio"
 

--- a/src/multilspy/multilspy_config.py
+++ b/src/multilspy/multilspy_config.py
@@ -4,6 +4,7 @@ Configuration parameters for Multilspy.
 
 from enum import Enum
 from dataclasses import dataclass
+from typing import Optional
 
 class Language(str, Enum):
     """
@@ -33,6 +34,15 @@ class MultilspyConfig:
     code_language: Language
     trace_lsp_communication: bool = False
     start_independent_lsp_process: bool = True
+
+    # Path to a pre-installed language server binary. When set, multilspy
+    # skips downloading the server and uses this binary directly.
+    server_binary: Optional[str] = None
+
+    # Directory where multilspy should download/install language server
+    # artifacts. Defaults to ~/.multilspy/lsp/<server_name>/ when None.
+    # Ignored when server_binary is set.
+    server_install_dir: Optional[str] = None
 
     @classmethod
     def from_dict(cls, env: dict):

--- a/src/multilspy/multilspy_settings.py
+++ b/src/multilspy/multilspy_settings.py
@@ -19,6 +19,14 @@ class MultilspySettings:
         return lsp_dir
 
     @staticmethod
+    def get_server_install_directory(server_name: str) -> str:
+        """Returns the install directory for a specific language server"""
+        lsp_dir = MultilspySettings.get_language_server_directory()
+        server_dir = str(pathlib.PurePath(lsp_dir, server_name))
+        os.makedirs(server_dir, exist_ok=True)
+        return server_dir
+
+    @staticmethod
     def get_global_cache_directory() -> str:
         """Returns the cache directory"""
         global_cache_dir = os.path.join(str(pathlib.Path.home()), ".multilspy", "global_cache")


### PR DESCRIPTION
## Summary

Language servers were downloading binaries into the Python package's `site-packages` directory (`os.path.dirname(__file__) + "/static/"`). This is unconventional — `site-packages` isn't meant to be writable at runtime — and breaks with read-only package installations.

### New config options

```python
config = MultilspyConfig.from_dict({
    "code_language": "rust",
    # Point to a pre-installed binary — skips download entirely
    "server_binary": "/usr/local/bin/rust-analyzer",
    # Or override where multilspy downloads server artifacts
    "server_install_dir": "/my/custom/cache/dir",
})
```

### Changes

- **Default install location** is now `~/.multilspy/lsp/<server_name>/` instead of `<package>/static/`
- **`config.server_binary`**: skip download entirely, use a pre-installed binary at the given path
- **`config.server_install_dir`**: override the install location for server artifacts
- **Fix #131**: check executable existence instead of directory existence (handles interrupted downloads)
- All 10 language servers updated consistently

| Server | `server_binary` | `server_install_dir` |
|---|---|---|
| rust-analyzer | returns binary path | `~/.multilspy/lsp/RustAnalyzer/` |
| dart | returns binary + args | `~/.multilspy/lsp/dart-language-server/` |
| clangd | returns binary path | `~/.multilspy/lsp/clangd/` |
| omnisharp | returns binary, `""` | `~/.multilspy/lsp/OmniSharp/` |
| typescript | returns binary + `--stdio` | `~/.multilspy/lsp/ts-lsp/` |
| eclipse jdtls | N/A (multi-binary) | `~/.multilspy/lsp/EclipseJDTLS/` |
| kotlin | N/A (multi-binary) | `~/.multilspy/lsp/KotlinLanguageServer/` |
| jedi | uses as cmd directly | N/A (pip dependency) |
| gopls | uses as cmd, skips checks | N/A (system binary) |
| solargraph | returns binary path | N/A (gem dependency) |

Fixes #136, fixes #131, fixes #109