### PR TITLE
Upgrade JDTLS to vscode-java v1.46.0 with Java 21, Gradle 7.6.6

### DIFF
--- a/src/multilspy/language_servers/eclipse_jdtls/eclipse_jdtls.py
+++ b/src/multilspy/language_servers/eclipse_jdtls/eclipse_jdtls.py
@@ -152,17 +152,18 @@ class EclipseJDTLS(LanguageServer):
         static_dir = config.server_install_dir or MultilspySettings.get_server_install_directory("EclipseJDTLS")
         os.makedirs(static_dir, exist_ok=True)
 
+        gradle_version = runtimeDependencies["gradle"]["platform-agnostic"]["version"]
         gradle_path = str(
             PurePath(
                 static_dir,
-                "gradle-7.3.3",
+                f"gradle-{gradle_version}",
             )
         )
 
         if not os.path.exists(gradle_path):
             FileUtils.download_and_extract_archive(
                 logger,
-                runtimeDependencies["gradle"]["platform-agnostic"]["url"],
+                runtimeDependencies["gradle"]["platform-agnostic"]["url"].format(version=gradle_version),
                 str(PurePath(gradle_path).parent),
                 runtimeDependencies["gradle"]["platform-agnostic"]["archiveType"],
             )
@@ -276,10 +277,10 @@ class EclipseJDTLS(LanguageServer):
         d["initializationOptions"]["bundles"] = bundles
 
         assert d["initializationOptions"]["settings"]["java"]["configuration"]["runtimes"] == [
-            {"name": "JavaSE-17", "path": "static/vscode-java/extension/jre/17.0.8.1-linux-x86_64", "default": True}
+            {"name": "JavaSE-21", "path": "static/vscode-java/extension/jre/21.0.8-linux-x86_64", "default": True}
         ]
         d["initializationOptions"]["settings"]["java"]["configuration"]["runtimes"] = [
-            {"name": "JavaSE-17", "path": self.runtime_dependency_paths.jre_home_path, "default": True}
+            {"name": "JavaSE-21", "path": self.runtime_dependency_paths.jre_home_path, "default": True}
         ]
 
         for runtime in d["initializationOptions"]["settings"]["java"]["configuration"]["runtimes"]:
@@ -289,7 +290,7 @@ class EclipseJDTLS(LanguageServer):
                 runtime["path"]
             ), f"Runtime required for eclipse_jdtls at path {runtime['path']} does not exist"
 
-        assert d["initializationOptions"]["settings"]["java"]["import"]["gradle"]["home"] == "abs(static/gradle-7.3.3)"
+        assert d["initializationOptions"]["settings"]["java"]["import"]["gradle"]["home"] == "abs(static/gradle-7.6.6)"
         d["initializationOptions"]["settings"]["java"]["import"]["gradle"][
             "home"
         ] = self.runtime_dependency_paths.gradle_path

--- a/src/multilspy/language_servers/eclipse_jdtls/initialize_params.json
+++ b/src/multilspy/language_servers/eclipse_jdtls/initialize_params.json
@@ -510,8 +510,8 @@
                     "workspaceCacheLimit": 90,
                     "runtimes": [
                         {
-                            "name": "JavaSE-17",
-                            "path": "static/vscode-java/extension/jre/17.0.8.1-linux-x86_64",
+                            "name": "JavaSE-21",
+                            "path": "static/vscode-java/extension/jre/21.0.8-linux-x86_64",
                             "default": true
                         }
                     ]
@@ -533,7 +533,7 @@
                             "enabled": true
                         },
                         "version": null,
-                        "home": "abs(static/gradle-7.3.3)",
+                        "home": "abs(static/gradle-7.6.6)",
                         "java": {
                             "home": "abs(static/launch_jres/17.0.6-linux-x86_64)"
                         },

--- a/src/multilspy/language_servers/eclipse_jdtls/runtime_dependencies.json
+++ b/src/multilspy/language_servers/eclipse_jdtls/runtime_dependencies.json
@@ -2,70 +2,71 @@
     "_description": "This file lists the runtime dependencies for the Java Language Server",
     "gradle": {
         "platform-agnostic": {
-            "url": "https://services.gradle.org/distributions/gradle-7.3.3-bin.zip",
+            "version": "7.6.6",
+            "url": "https://services.gradle.org/distributions/gradle-{version}-bin.zip",
             "archiveType": "zip",
             "relative_extraction_path": "."
         }
     },
     "vscode-java": {
         "darwin-arm64": {
-            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@darwin-arm64-1.23.0.vsix",
+            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.46.0/java-darwin-arm64-1.46.0-711.vsix",
             "archiveType": "zip",
             "relative_extraction_path": "vscode-java"
         },
         "osx-arm64": {
-            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@darwin-x64-1.23.0.vsix",
+            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.46.0/java-darwin-arm64-1.46.0-711.vsix",
             "archiveType": "zip",
             "relative_extraction_path": "vscode-java",
-            "jre_home_path": "extension/jre/17.0.8.1-macosx-x86_64",
-            "jre_path": "extension/jre/17.0.8.1-macosx-x86_64/bin/java",
-            "lombok_jar_path": "extension/lombok/lombok-1.18.30.jar",
-            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.6.500.v20230717-2134.jar",
+            "jre_home_path": "extension/jre/21.0.8-macosx-aarch64",
+            "jre_path": "extension/jre/21.0.8-macosx-aarch64/bin/java",
+            "lombok_jar_path": "extension/lombok/lombok-1.18.39-4050.jar",
+            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.7.0.v20250519-0528.jar",
             "jdtls_readonly_config_path": "extension/server/config_mac_arm"
         },
         "osx-x64": {
-            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@darwin-x64-1.23.0.vsix",
+            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.46.0/java-darwin-x64-1.46.0-711.vsix",
             "archiveType": "zip",
             "relative_extraction_path": "vscode-java",
-            "jre_home_path": "extension/jre/17.0.8.1-macosx-x86_64",
-            "jre_path": "extension/jre/17.0.8.1-macosx-x86_64/bin/java",
-            "lombok_jar_path": "extension/lombok/lombok-1.18.30.jar",
-            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.6.500.v20230717-2134.jar",
+            "jre_home_path": "extension/jre/21.0.8-macosx-x86_64",
+            "jre_path": "extension/jre/21.0.8-macosx-x86_64/bin/java",
+            "lombok_jar_path": "extension/lombok/lombok-1.18.39-4050.jar",
+            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.7.0.v20250519-0528.jar",
             "jdtls_readonly_config_path": "extension/server/config_mac"
         },
         "linux-arm64": {
-            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@linux-arm64-1.23.0.vsix",
+            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.46.0/java-linux-arm64-1.46.0-711.vsix",
             "archiveType": "zip",
             "relative_extraction_path": "vscode-java"
         },
         "linux-x64": {
-            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@linux-x64-1.23.0.vsix",
+            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.46.0/java-linux-x64-1.46.0-711.vsix",
             "archiveType": "zip",
             "relative_extraction_path": "vscode-java",
-            "jre_home_path": "extension/jre/17.0.8.1-linux-x86_64",
-            "jre_path": "extension/jre/17.0.8.1-linux-x86_64/bin/java",
-            "lombok_jar_path": "extension/lombok/lombok-1.18.30.jar",
-            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.6.500.v20230717-2134.jar",
+            "jre_home_path": "extension/jre/21.0.8-linux-x86_64",
+            "jre_path": "extension/jre/21.0.8-linux-x86_64/bin/java",
+            "lombok_jar_path": "extension/lombok/lombok-1.18.39-4050.jar",
+            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.7.0.v20250519-0528.jar",
             "jdtls_readonly_config_path": "extension/server/config_linux"
         },
         "win-x64": {
-            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@win32-x64-1.23.0.vsix",
+            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.46.0/java-win32-x64-1.46.0-711.vsix",
             "archiveType": "zip",
             "relative_extraction_path": "vscode-java",
-            "jre_home_path": "extension/jre/17.0.8.1-win32-x86_64",
-            "jre_path": "extension/jre/17.0.8.1-win32-x86_64/bin/java.exe",
-            "lombok_jar_path": "extension/lombok/lombok-1.18.30.jar",
-            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.6.500.v20230717-2134.jar",
+            "jre_home_path": "extension/jre/21.0.8-win32-x86_64",
+            "jre_path": "extension/jre/21.0.8-win32-x86_64/bin/java.exe",
+            "lombok_jar_path": "extension/lombok/lombok-1.18.39-4050.jar",
+            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.7.0.v20250519-0528.jar",
             "jdtls_readonly_config_path": "extension/server/config_win"
         }
     },
     "intellicode": {
         "platform-agnostic": {
-            "url": "https://VisualStudioExptTeam.gallery.vsassets.io/_apis/public/gallery/publisher/VisualStudioExptTeam/extension/vscodeintellicode/1.2.30/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage",
-            "alternate_url": "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/VisualStudioExptTeam/vsextensions/vscodeintellicode/1.2.30/vspackage",
+            "url": "https://VisualStudioExptTeam.gallery.vsassets.io/_apis/public/gallery/publisher/VisualStudioExptTeam/extension/vscodeintellicode/1.3.2/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage",
+            "alternate_url": "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/VisualStudioExptTeam/vsextensions/vscodeintellicode/1.3.2/vspackage",
             "archiveType": "zip",
             "relative_extraction_path": "intellicode",
-            "intellicode_jar_path": "extension/dist/com.microsoft.jdtls.intellicode.core-0.7.0.jar",
+            "intellicode_jar_path": "extension/dist/com.microsoft.jdtls.intellicode.core-0.7.1.jar",
             "intellisense_members_path": "extension/dist/bundledModels/java_intellisense-members"
         }
     }


### PR DESCRIPTION
## Summary

Upgrades Eclipse JDTLS runtime dependencies to current versions. Incorporates and supersedes #126 (@vergenzt) and #128 (@gruckion), resolving their merge conflicts with current main.

### Version changes

| Component | Old | New |
|---|---|---|
| vscode-java | v1.23.0 | v1.46.0 |
| Bundled JRE | Java 17 | Java 21 |
| Gradle | 7.3.3 | 7.6.6 |
| Lombok | 1.18.30 | 1.18.39 |
| IntelliCode | 1.2.30 | 1.3.2 |
| Equinox launcher | 1.6.500 | 1.7.0 |

### Fixes
- **osx-arm64**: was incorrectly downloading the x64 binary (caught by both #126 and #128)
- **JavaSE-17 → JavaSE-21**: runtime config name updated in `eclipse_jdtls.py` and `initialize_params.json` (caught by @gruckion in #128)
- **Gradle URL templating**: version extracted from JSON, URL uses `{version}` placeholder (from @vergenzt in #126)

### Attribution
Based on work by @vergenzt (#126) and @gruckion (#128). Contributors credited in commit message.

Closes #126, closes #128.